### PR TITLE
Return org.gradle.api.artifacts.Configuration with an artifact built by EmbulkPluginJar

### DIFF
--- a/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
+++ b/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
@@ -36,6 +36,13 @@ class EmbulkPluginJar extends Jar {
         super.copy()
     }
 
+    Configuration getArtifacts() {
+        Configuration artifactConfiguration = project.configurations.detachedConfiguration()
+        org.gradle.api.artifacts.ConfigurationPublications publications = artifactConfiguration.getOutgoing()
+        publications.artifact(this)
+        return artifactConfiguration
+    }
+
     String getMainClass() {
         return this.mainClass
     }


### PR DESCRIPTION
@muga This is the change that continues to the next update -- to upload the built Embulk plugin JAR file to somewhere. Can you have a look?

With this change, `gradle install` and/or `gradle upload` would be easier with `EmbulkPluginJar` like following:

```
plugins {
   ...
    id "maven"
}
apply plugin: "org.embulk.plugins.gradle"

embulkPluginJar {
    mainClass = "org.embulk.output.example.ExampleOutputPlugin"
}

install {
    configuration = embulkPluginJar.artifacts
}
```