### PR TITLE
Fix: Include original files with calling "with project.jar"

### DIFF
--- a/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
+++ b/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
@@ -5,6 +5,11 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Jar
 
 class EmbulkPluginJar extends Jar {
+    EmbulkPluginJar() {
+        super()
+        with project.jar
+    }
+
     @TaskAction
     @Override
     void copy() {


### PR DESCRIPTION
@muga Sorry, I was not aware of one problem.

While dependencies are correctly included in the result jar file, the plugin's original files (e.g. `org.embulk.input.ftp...`) are not included there!

This PR fixes the problem.