### PR TITLE
Fix "Could not get unknown property 'jar' for root project" when applied from plugin { ... }

### DIFF
--- a/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
+++ b/src/main/groovy/org/embulk/plugins/gradle/tasks/EmbulkPluginJar.groovy
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.bundling.Jar
 class EmbulkPluginJar extends Jar {
     EmbulkPluginJar() {
         super()
-        with project.jar
+        with project.tasks.create("__embulk_plugin_jar_internal_jar__", Jar)
     }
 
     @TaskAction


### PR DESCRIPTION
It failed to apply when applying this plugin from the Gradle Plugin Portal with `plugins { ... }` block. `project.(tasks.)jar` has not been declared within `plugins { ... }` block yet.

Then as a workaround, creating a new `Jar` type task tentatively there. Confirmed that the fix makes it work.

@muga Can you have a look later? I'm merging this and releasing v0.0.2 soon on my side.