### PR TITLE
Add `gem` support, update README.md, and bump up to v0.2.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,260 @@ Quick Guide
 ------------
 
 ```
-apply plugin: 'org.embulk.plugins.gradle'
-
-embulkPluginJar {
-    mainClass = "org.embulk.input.example.ExampleInputPlugin"  // Mandatory
-    // configurationForProvidedDependencies = configurations.provided  // Default: "configurations.provided"
-    // destinationDir = "pkg"  // Default: "pkg"
-    // extractsDependencies = true  // Default: true
-}
-
-uploadEmbulkPluginJar {
-    configuration = embulkPluginJar.artifacts
-    mavenDeployer {
-        repository(url: "file:///path/to/maven/repository")
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        // Enable this when you want to publish your plugin as a gem.
+        // classpath "com.github.jruby-gradle:jruby-gradle-plugin:1.7.0"
+        classpath "gradle.plugin.org.embulk:gradle-embulk-plugin:0.2.1"
     }
 }
 
-task myEmbulkPluginJar(type: org.embulk.plugins.gradle.EmbulkPluginJar) {
-    mainClass = "org.embulk.output.example.ExampleOutputPlugin"  // Mandatory
-    configurationForProvidedDependencies = configurations.myProvided
-    destinationDir = "my_pkg"
-    extractsDependencies = false
-    pluginClassPathDir = "classpath"
+apply plugin: "java"
+apply plugin: "maven"
+
+// Enable this when you want to publish your plugin as a gem.
+// apply plugin: "com.github.jruby-gradle.base"
+
+// Once this Gradle plugin is applied, its dependencies are automatically updated to be flattened.
+// The update affects the default `jar` task, and default Maven uploading mechanisms as well.
+apply plugin: "org.embulk.embulk-plugins"
+
+group = "com.example"
+version = "0.1.5-ALPHA"
+description = "An Embulk plugin to load example data."
+
+repositories {
+    mavenCentral()
+    jcenter()
 }
 
-task myUploadEmbulkPluginJar(type: org.embulk.plugins.gradle.tasks.MavenUploadEmbulkPluginJar) {
-    configuration = myEmbulkPluginJar.artifacts
-    mavenDeployer {
-        repository(url: "file:///path/to/another/maven/repository")
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.17"
+
+    testCompile "junit:junit:4.12"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.example.ExampleInputPlugin"
+    category = "input"
+    type = "example"
+}
+
+// You can use any uploading mechanism as you like (e.g. `maven-publish`).
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            repository(url: "file:${project.buildDir}/mavenLocal")
+            snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
+        }
     }
 }
+
+// Enable this when you want to publish your plugin as a gem.
+// Note that `gem` is a type of archive tasks such as `jar` and `zip`, with some additional properties to fulfill `.gemspec`.
+//
+// gem {
+//     from("LICENSE.txt")
+//     authors = [ "Somebody Somewhere" ]
+//     email = [ "somebody@example.com" ]
+//     summary = "Example input plugin for Embulk"
+//     homepage = "https://example.com"
+//     licenses = [ "Apache-2.0" ]
+//     metadata = [
+//         "foo": "bar"
+//     ]
+// }
+
+// Enable this when you want to publish your plugin as a gem.
+// Note that the `host` property is mandatory.
+//
+// gemPush {
+//     host = "https://rubygems.org"
+// }
 ```
+
+### How to migrate old-style `build.gradle` of your Embulk plugins
+
+1. Upgrade your Gradle wrapper to `5.5.1+`.
+2. Define `group`, `version`, and `description` in your Gradle project.
+    * `group` should **NOT** be `"org.embulk"` unless your project is under: https://github.com/embulk. For example:
+      ```
+      group = "com.example"
+      version = "0.1.5-SNAPSHOT"
+      description = "An Embulk plugin to load example data."
+      ```
+3. Replace `compile` and `provided` in your dependencies to `compileOnly`.
+    * Old:
+      ```
+      compile "org.embulk:embulk-core:0.9.17"
+      provided "org.embulk:embulk-core:0.9.17"
+      ```
+    * New:
+      ```
+      compileOnly "org.embulk:embulk-core:0.9.17"
+      ```
+4. **Remove** an unnecessary configuration.
+    * `provided`
+    ```
+    configurations {
+        provided
+    }
+    ```
+5. **Remove** unnecessary tasks.
+    * `classpath`
+    ```
+    task classpath(type: Copy, dependsOn: ["jar"]) {
+        doFirst { file("classpath").deleteDir() }
+        from (configurations.runtime - configurations.provided + files(jar.archivePath))
+        into "classpath"
+    }
+    clean { delete "classpath" }
+    ```
+    * `gem`: a task with the same name is defined in this Gradle plugin
+    ```
+    task gem(type: JRubyExec, dependsOn: ["gemspec", "classpath"]) {
+        jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "build"
+        script "${project.name}.gemspec"
+        doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }
+    }
+    ```
+    * `gemPush`: a task with the same name is defined in this Gradle plugin
+    ```
+    task gemPush(type: JRubyExec, dependsOn: ["gem"]) {
+        jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "push"
+        script "pkg/${project.name}-${project.version}.gem"
+    }
+    ```
+    * `package`
+    ```
+    task "package"(dependsOn: ["gemspec", "classpath"]) {
+        doLast {
+            println "> Build succeeded."
+            println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+        }
+    }
+    ```
+    * `gemspec`: the `gem` task defined in this Gradle plugin generates `.gemspec` under `build/`, and uses it to build a gem
+    ```
+    task gemspec {
+        ext.gemspecFile = file("${project.name}.gemspec")
+        inputs.file "build.gradle"
+        outputs.file gemspecFile
+        doLast { gemspecFile.write($/
+    Gem::Specification.new do |spec|
+      spec.name          = "${project.name}"
+      spec.version       = "${project.version}"
+      spec.authors       = ["Somebody Somewhere"]
+      spec.summary       = %[Example input plugin for Embulk]
+      spec.description   = %[An Embulk plugin to load example data.]
+      spec.email         = ["somebody@example.com"]
+      spec.licenses      = ["MIT"]
+      spec.homepage      = "https://example.com"
+
+      spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]
+      spec.test_files    = spec.files.grep(%r"^(test|spec)/")
+      spec.require_paths = ["lib"]
+
+      #spec.add_dependency 'YOUR_GEM_DEPENDENCY', ['~> YOUR_GEM_DEPENDENCY_VERSION']
+      spec.add_development_dependency 'bundler'
+      spec.add_development_dependency 'rake', ['>= 10.0']
+    end
+    /$)
+        }
+    }
+    clean { delete "${project.name}.gemspec" }
+    ```
+6. Remove an unnecessary file.
+    * `lib/embulk/<category>/<type>.rb`: the `gem` task defined in this Gradle plugin generates this `.rb` file under `build/` behind, and includes it in the gem. For example of `lib/embulk/input/example.rb`:
+      ```
+      Embulk::JavaPlugin.register_input(
+        "example", "org.embulk.input.example.ExampleInputPlugin",
+        File.expand_path('../../../../classpath', __FILE__))
+      ```
+7. Apply this Gradle plugin `"org.embulk.embulk-plugins"`.
+    * Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+      ```
+      plugins {
+          id "org.embulk.embulk-plugins" version "0.2.1"
+      }
+    * Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
+      ```
+      buildscript {
+          repositories {
+          maven {
+              url "https://plugins.gradle.org/m2/"
+          }
+      }
+      dependencies {
+          classpath "gradle.plugin.org.embulk:gradle-embulk-plugins:0.2.1"
+      }
+
+      apply plugin: "org.embulk.embulk-plugins"
+      ```
+8. Configure the task `embulkPlugin`.
+    * `mainClass`, `category`, and `type` are mandatory. For example:
+    ```
+    embulkPlugin {
+        mainClass = "org.embulk.input.dummy.DummyInputPlugin"
+        category = "input"
+        type = "dummy"
+    }
+9. Configure uploading the plugin JAR to the Maven repository where you want to upload.
+    * The standard `jar` task is updated to generate a JAR ready as an Embulk plugin. For example of `uploadArchives`:
+    ```
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                repository(url: "file:${project.buildDir}/mavenLocal")
+                snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
+            }
+        }
+    }
+    ```
+10. Configure more to publish your plugin as a gem.
+    * Apply the JRuby/Gradle plugin (the latest of its version 1.*):
+        * Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+          ```
+          plugins {
+              id "com.github.jruby-gradle.base" version "1.7.0"
+          }
+        * Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
+          ```
+          buildscript {
+              repositories {
+                  maven {
+                      url "https://plugins.gradle.org/m2/"
+                  }
+              }
+              dependencies {
+                  classpath "com.github.jruby-gradle:jruby-gradle-plugin:1.7.0"
+              }
+          }
+
+          apply plugin: "com.github.jruby-gradle.base"
+          ```
+    * Configure the `gem` task. Note that `gem` is a type of archive tasks such as `jar` and `zip`, with some additional properties to fulfill `.gemspec`:
+      ```
+      gem {
+          from("LICENSE")
+          authors = [ "Somebody Somewhere" ]
+          email = [ "somebody@example.com" ]
+          summary = "Example input plugin for Embulk"
+          homepage = "https://example.com"
+          licenses = [ "Apache-2.0" ]
+          metadata = [
+              "foo": "bar"
+          ]
+      }
+      ```
+    * Configure the `gemPush` task. Note that the `host` property is mandatory:
+      ```
+      gemPush {
+          host = "https://rubygems.org"
+      }
+      ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,16 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.10.1"
-    }
+plugins {
+    id "java"
+    id "maven"
+    id "java-gradle-plugin"
+    id "com.gradle.plugin-publish" version "0.10.1"
 }
 
-apply plugin: "maven"
-apply plugin: "java-gradle-plugin"
-apply plugin: "com.gradle.plugin-publish"
-
+// This Gradle plugin is published under the group "gradle.plugin.org.embulk".
+// We have an option to avoid the "gradle.plugin" prefix, but we don't do it as it bothers the Gradle team.
+// They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
+// https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-archivesBaseName = "${project.name}"
-version = "0.2.0-SNAPSHOT"
+version = "0.2.1-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -16,21 +16,22 @@
 
 package org.embulk.gradle.embulk_plugins;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedDependency;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.maven.Conf2ScopeMapping;
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.plugins.MavenPlugin;
-import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
@@ -45,17 +46,28 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         this.applyPlugin(project, "maven");
 
+        final Class<JavaExec> jrubyExecClass = loadJRubyExecClass(project);
+        if (jrubyExecClass != null) {
+            this.applyPlugin(project, "com.github.jruby-gradle.base");
+            project.getLogger().lifecycle("[gradle-embulk-plugins] JRuby/Gradle is applied.");
+        }
+
         final EmbulkPluginExtension extension = createExtension(project);
+        project.afterEvaluate(projectInner -> {
+            extension.checkValidity();
+        });
 
         final Configuration runtimeConfiguration = project.getConfigurations().getByName("runtime");
         final Configuration flatRuntimeConfiguration =
-                project.getConfigurations().create(extension.getFlatRuntimeConfiguration());
+                project.getConfigurations().create(extension.getFlatRuntimeConfiguration().get());
 
         this.configureFlatRuntime(project, runtimeConfiguration, flatRuntimeConfiguration);
 
         this.replaceConf2ScopeMappings(project, runtimeConfiguration, flatRuntimeConfiguration);
 
         this.configureJarTask(project, extension);
+
+        this.configureGemTasks(project, extension, runtimeConfiguration, jrubyExecClass);
     }
 
     /**
@@ -132,18 +144,101 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
     /**
      * Configures the standard {@code "jar"} task with required MANIFEST.
      */
-    private void configureJarTask(final Project project, final EmbulkPluginExtension extension) {
-        project.getTasks().named("jar", Jar.class, new Action<Jar>() {
-            @Override
-            public void execute(final Jar jarTask) {
+    private void configureJarTask(final Project originalProject, final EmbulkPluginExtension extension) {
+        originalProject.afterEvaluate(project -> {
+            project.getTasks().named("jar", Jar.class, jarTask -> {
                 jarTask.manifest(UpdateManifestAction.builder()
-                                 .add("Embulk-Plugin-Main-Class", extension.getMainClass())
+                                 .add("Embulk-Plugin-Main-Class", extension.getMainClass().get())
+                                 .add("Embulk-Plugin-Category", extension.getCategory().get())
+                                 .add("Embulk-Plugin-Type", extension.getType().get())
                                  .add("Embulk-Plugin-Spi-Version", "0")
                                  .add("Implementation-Title", project.getName())
                                  .add("Implementation-Version", project.getVersion().toString())
                                  .build());
-            }
+            });
         });
+    }
+
+    private void configureGemTasks(
+            final Project originalProject,
+            final EmbulkPluginExtension extension,
+            final Configuration runtimeConfiguration,
+            final Class<JavaExec> jrubyExecClass) {
+        if (jrubyExecClass != null) {
+            originalProject.getTasks().create("gem", Gem.class, task -> {
+                task.dependsOn("jar");
+            });
+
+            originalProject.getTasks().create("gemPush", GemPush.class, task -> {
+                task.dependsOn("gem");
+            });
+
+            originalProject.afterEvaluate(project -> {
+                project.getTasks().named("gem", Gem.class, task -> {
+                    task.setEmbulkPluginMainClass(extension.getMainClass().get());
+                    task.setEmbulkPluginCategory(extension.getCategory().get());
+                    task.setEmbulkPluginType(extension.getType().get());
+
+                    if ((!task.getArchiveBaseName().isPresent())) {
+                        // project.getName() never returns null.
+                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getName--
+                        task.getArchiveBaseName().set(project.getName());
+                    }
+                    // summary is kept empty -- mandatory.
+                    if ((!task.getArchiveVersion().isPresent()) && (!project.getVersion().toString().equals("unspecified"))) {
+                        // project.getVersion() never returns null.
+                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getVersion--
+                        task.getArchiveVersion().set(buildGemVersionFromMavenVersion(project.getVersion().toString()));
+                    }
+
+                    if (!task.getGemDescription().isPresent() && project.getDescription() != null) {
+                        // project.getDescription() may return null.
+                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getDescription--
+                        task.getGemDescription().set(project.getDescription());
+                    }
+
+                    task.checkValidity(project);
+
+                    task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
+                    task.from(runtimeConfiguration, copySpec -> {
+                        copySpec.into("classpath");
+                    });
+                    task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
+                        copySpec.into("classpath");
+                    });
+                });
+            });
+        }
+    }
+
+    private static String buildGemVersionFromMavenVersion(final String mavenVersion) {
+        if (mavenVersion.contains("-")) {
+            final List<String> versionTokens = Arrays.asList(mavenVersion.split("-"));
+            if (versionTokens.size() != 2) {
+                throw new GradleException("'version' not available for Gem-style versioning: " + mavenVersion);
+            }
+            return versionTokens.get(0) + '.' + versionTokens.get(1).toLowerCase();
+        }
+        else {
+            return mavenVersion;
+        }
+    }
+
+    private Class<JavaExec> loadJRubyExecClass(final Project project) {
+        try {
+            final Class<JavaExec> jrubyExecClass = loadJRubyExecClassInternal(this.getClass().getClassLoader());
+            project.getLogger().lifecycle("[gradle-embulk-plugins] JRuby/Gradle is here. Gem-related tasks are ready for Embulk plugins.");
+            return jrubyExecClass;
+        } catch (final ClassNotFoundException | ClassCastException ex) {
+            project.getLogger().warn("[gradle-embulk-plugins] JRuby/Gradle is not loaded. Apply \"com.github.jruby-gradle.base\" to activate Gem-related tasks for Embulk plugins.");
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<JavaExec> loadJRubyExecClassInternal(final ClassLoader classLoader)
+            throws ClassNotFoundException, ClassCastException {
+        return (Class<JavaExec>) classLoader.loadClass("com.github.jrubygradle.JRubyExec");
     }
 
     /**

--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.file.copy.CopyAction;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.process.ExecResult;
+
+/**
+ * A Gradle task to build a gem.
+ */
+class Gem extends AbstractArchiveTask {
+    @Inject
+    public Gem() {
+        super();
+
+        final ObjectFactory objectFactory = this.getProject().getObjects();
+
+        this.embulkPluginMainClass = objectFactory.property(String.class);
+        this.embulkPluginCategory = objectFactory.property(String.class);
+        this.embulkPluginType = objectFactory.property(String.class);
+
+        this.authors = objectFactory.listProperty(String.class);
+        this.summary = objectFactory.property(String.class);
+
+        this.gemDescription = objectFactory.property(String.class);
+        this.email = objectFactory.listProperty(String.class);
+        this.homepage = objectFactory.property(String.class);
+        this.licenses = objectFactory.listProperty(String.class);
+        // https://guides.rubygems.org/specification-reference/#metadata
+        this.metadata = objectFactory.mapProperty(String.class, String.class);
+
+        this.getArchiveExtension().set("gem");
+    }
+
+    @Override
+    protected CopyAction createCopyAction() {
+        final Project project = this.getProject();
+
+        this.cleanIfExists(project);
+
+        // Copying the source files into the working directory. Note that the Gem task should not have top-level `into`
+        // because AbstractArchiveTask#into represents a destination directory *inside* the archive for the files.
+        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/tasks/bundling/AbstractArchiveTask.html#into-java.lang.Object-
+        project.copy(copySpec -> {
+            copySpec.with(this);
+            copySpec.into(this.getWorkingDir(project).toFile());
+        });
+        this.createBootstrap(project);
+        this.createGemspec(project, this.listFiles(project));
+
+        // Looking up an appropriate jruby-complete JAR via the JRuby/Gradle plugin.
+        final Configuration jrubyExecConfiguration = project.getConfigurations().getByName("jrubyExec");
+        File jrubyCompleteFileFound = null;
+        for (final File file : jrubyExecConfiguration.getFiles()) {
+            if (file.getName().startsWith("jruby-complete")) {
+                if (jrubyCompleteFileFound == null) {
+                    jrubyCompleteFileFound = file;
+                } else {
+                    throw new GradleException("Multiple jruby-complete runtimes are found.");
+                }
+                break;
+            }
+        }
+
+        if (jrubyCompleteFileFound == null) {
+            throw new GradleException("No jruby-complete runtime is found.");
+        }
+        final File jrubyCompleteFile = jrubyCompleteFileFound;
+        project.getLogger().lifecycle("Using JRuby at: " + jrubyCompleteFile.toString());
+
+        final ArrayList<String> args = new ArrayList<>();
+        args.add("-rjars/setup");
+        args.add("-S");
+        args.add("gem");
+        args.add("build");
+        args.add(project.getName() + ".gemspec");
+        project.getLogger().lifecycle("Running: `java org.jruby.Main " + String.join(" ", args) + "`");
+
+        final ExecResult execResult = project.javaexec(javaExecSpec -> {
+            javaExecSpec.setWorkingDir(getWorkingDir(project).toFile());
+            javaExecSpec.setClasspath(project.files(jrubyCompleteFile));
+            javaExecSpec.setMain("org.jruby.Main");
+            javaExecSpec.setArgs(args);
+
+            final HashMap<String, Object> environments = new HashMap<>();
+            environments.putAll(System.getenv());
+            environments.putAll(javaExecSpec.getEnvironment());
+            /*
+            environments.put(
+                'JBUNDLE_SKIP' : true,
+                'JARS_SKIP' : true,
+                'PATH' : getComputedPATH(System.getenv().get(JRubyExecUtils.pathVar())),
+                'GEM_HOME' : getGemWorkDir().absolutePath,
+                'GEM_PATH' : getGemWorkDir().absolutePath,
+                'JARS_HOME' : new File(getGemWorkDir().absolutePath, 'jars'),
+                'JARS_LOCK' : new File(getGemWorkDir().absolutePath, 'Jars.lock')
+            */
+            javaExecSpec.setEnvironment(environments);
+        });
+        execResult.assertNormalExitValue();
+
+        project.getLogger().lifecycle("The `gem build` command has finished successfully.");
+
+        return new GemCopyAction(
+                this.getWorkingDir(project).resolve(project.getName() + "-" + this.getArchiveVersion().get() + "-java.gem"),
+                this.getArchiveFile());
+    }
+
+    public ListProperty<String> getAuthors() {
+        return this.authors;
+    }
+
+    public Property<String> getSummary() {
+        return this.summary;
+    }
+
+    public Property<String> getGemDescription() {
+        return this.gemDescription;
+    }
+
+    public ListProperty<String> getEmail() {
+        return this.email;
+    }
+
+    public Property<String> getHomepage() {
+        return this.homepage;
+    }
+
+    public ListProperty<String> getLicenses() {
+        return this.licenses;
+    }
+
+    public MapProperty<String, String> getMetadata() {
+        return this.metadata;
+    }
+
+    public void checkValidity(final Project project) {
+        final ArrayList<String> errors = new ArrayList<>();
+        if ((!this.authors.isPresent()) || this.authors.get().isEmpty()) {
+            errors.add("'authors' must not be empty in 'gem'.");
+        }
+        if ((!this.getArchiveBaseName().isPresent()) || this.getArchiveBaseName().get().isEmpty()) {
+            errors.add("'archiveBaseName' must be available of 'gem'.");
+        }
+        if ((!this.summary.isPresent()) || this.summary.get().isEmpty()) {
+            errors.add("'summary' must be available in 'gem'.");
+        }
+        if ((!this.getArchiveVersion().isPresent()) || this.getArchiveVersion().get().isEmpty()) {
+            errors.add("'archiveVersion' must be available in 'gem'.");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new GradleException("[gradle-embulk-plugins] " + String.join(" ", errors));
+        }
+
+        if (!this.gemDescription.isPresent()) {
+            project.getLogger().warn("[gradle-embulk-plugins] `project.description` or `gemDescription` in `gem` is recommended.");
+        }
+        if ((!this.email.isPresent()) || this.email.get().isEmpty()) {
+            project.getLogger().warn("[gradle-embulk-plugins] `email` is recommended in `gem`. For example: `email = [ \"foo@example.com\" ]");
+        }
+        if (!this.homepage.isPresent()) {
+            project.getLogger().warn("[gradle-embulk-plugins] `homepage` is recommended in `gem`. For example: `homepage = \"https://github.com/example/embulk-input-example\"");
+        }
+        if ((!this.licenses.isPresent()) || this.licenses.get().isEmpty()) {
+            project.getLogger().warn("[gradle-embulk-plugins] `licenses` is recommended in `gem`. For example: `licenses = [ \"Apache-2.0\" ]");
+        }
+    }
+
+    void setEmbulkPluginMainClass(final String embulkPluginMainClass) {
+        this.embulkPluginMainClass.set(embulkPluginMainClass);
+    }
+
+    void setEmbulkPluginCategory(final String embulkPluginCategory) {
+        this.embulkPluginCategory.set(embulkPluginCategory);
+    }
+
+    void setEmbulkPluginType(final String embulkPluginType) {
+        this.embulkPluginType.set(embulkPluginType);
+    }
+
+    private static String renderList(final List<String> strings) {
+        return String.join(", ", strings.stream().map(s -> "\"" + s + "\"").collect(Collectors.toList()));
+    }
+
+    private void cleanIfExists(final Project project) {
+        final Path root = this.getWorkingDir(project);
+        if (!Files.exists(root)) {
+            return;
+        }
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (final IOException ex) {
+            throw new GradleException("Could not clean the target directory: " + root.toString(), ex);
+        }
+    }
+
+    private void createBootstrap(final Project project) {
+        final Path dirPath = this.getWorkingDir(project).resolve("lib").resolve("embulk").resolve(this.embulkPluginCategory.get());
+        try {
+            Files.createDirectories(dirPath);
+        } catch (final IOException ex) {
+            throw new GradleException("Could not create: " + dirPath.toString(), ex);
+        }
+
+        final Path filePath = dirPath.resolve(this.embulkPluginType.get() + ".rb");
+        try (final PrintWriter writer = new PrintWriter(Files.newOutputStream(filePath, StandardOpenOption.CREATE_NEW))) {
+            writer.println("Embulk::JavaPlugin.register_" + this.embulkPluginCategory.get() + "(");
+            writer.println("  \"" + this.embulkPluginType.get() + "\", \"" + this.embulkPluginMainClass.get() + "\"");
+            writer.println("  File.expand_path(\"../../../../classpath\", __FILE__))");
+        } catch (final IOException ex) {
+            throw new GradleException("Could not create and write: " + filePath.toString(), ex);
+        }
+    }
+
+    private List<Path> listFiles(final Project project) {
+        final ArrayList<Path> files = new ArrayList<>();
+
+        final Path root = this.getWorkingDir(project);
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                    files.add(root.relativize(file));
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (final IOException ex) {
+            throw new GradleException("Could not list files in the directory: " + root.toString(), ex);
+        }
+
+        return Collections.unmodifiableList(files);
+    }
+
+    private void createGemspec(final Project project, final List<Path> files) {
+        final Path gemspecPath = this.getWorkingDir(project).resolve(project.getName() + ".gemspec");
+        try (final PrintWriter writer = new PrintWriter(Files.newOutputStream(gemspecPath, StandardOpenOption.CREATE_NEW))) {
+            this.dump(writer, files);
+        } catch (final IOException ex) {
+            throw new GradleException("Could not create and write: " + gemspecPath.toString(), ex);
+        }
+    }
+
+    private Path getWorkingDir(final Project project) {
+        return ((File) project.property("buildDir")).toPath().resolve("gemContents").normalize();
+    }
+
+    // https://guides.rubygems.org/specification-reference/
+    // https://maven.apache.org/ref/3.6.0/maven-model/apidocs/org/apache/maven/model/Model.html
+    private void dump(final PrintWriter writer, final List<Path> files) {
+        writer.println("Gem::Specification.new do |spec|");
+
+        // REQUIRED GEMSPEC ATTRIBUTES
+        writer.println("    spec.authors       = [" + renderList(this.authors.get()) + "]");
+        writer.println("    spec.files         = [");
+        for (final Path file : files) {
+            writer.println("        \"" + file.toString() + "\",");
+        }
+        writer.println("    ]");
+        writer.println("    spec.name          = \"" + this.getArchiveBaseName().get() + "\"");
+        writer.println("    spec.summary       = \"" + this.summary.get() + "\"");
+        writer.println("    spec.version       = \"" + this.getArchiveVersion().get() + "\"");
+
+        // RECOMMENDED GEMSPEC ATTRIBUTES
+        if (this.gemDescription.isPresent()) {
+            writer.println("    spec.description   = \"" + this.gemDescription.get() + "\"");
+        }
+        if (this.email.isPresent() && !this.email.get().isEmpty()) {
+            writer.println("    spec.email         = [" + renderList(this.email.get()) + "]");
+        }
+        if (this.homepage.isPresent()) {
+            writer.println("    spec.homepage      = \"" + this.homepage.get() + "\"");
+        }
+        if (this.licenses.isPresent() && !this.licenses.get().isEmpty()) {
+            writer.println("    spec.licenses      = [" + renderList(this.licenses.get()) + "]");
+        }
+        if (this.metadata.isPresent() && !this.metadata.get().isEmpty()) {
+            writer.println("    spec.metadata      = {");
+            for (final Map.Entry<String, String> entry : this.metadata.get().entrySet()) {
+                writer.println("        \"" + entry.getKey() + "\" => \"" + entry.getValue() + "\",");
+            }
+            writer.println("    }");
+        }
+
+        // OPTIONAL GEMSPEC ATTRIBUTES
+        // add_development_dependency
+        // add_runtime_dependency
+        // author=
+        // bindir
+        // cert_chain
+        // executables
+        // extensions
+        // extra_rdoc_files
+        writer.println("    spec.platform      = \"java\"");
+        // post_install_message
+        // rdoc_options
+        writer.println("    spec.require_paths = [ \"lib\" ]");
+        // required_ruby_version
+        // required_ruby_version=
+        // required_rubygems_version
+        // required_rubygems_version=
+        // requirements
+        // rubygems_version
+        // signing_key
+        writer.println("end");
+    }
+
+    private final Property<String> embulkPluginMainClass;
+    private final Property<String> embulkPluginCategory;
+    private final Property<String> embulkPluginType;
+
+    private final ListProperty<String> authors;
+    private final Property<String> summary;
+
+    private final Property<String> gemDescription;
+    private final ListProperty<String> email;
+    private final Property<String> homepage;
+    // The singular `license` is to be substituted by `licenses`.
+    private final ListProperty<String> licenses;
+    private final MapProperty<String, String> metadata;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemCopyAction.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemCopyAction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.file.copy.CopyAction;
+import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
+import org.gradle.api.provider.Provider;
+
+class GemCopyAction implements CopyAction {
+    public GemCopyAction(
+            final Path sourceGemFilePath,
+            final Provider<RegularFile> destinationGemFile) {
+        this.sourceGemFilePath = sourceGemFilePath;
+        this.destinationGemFile = destinationGemFile;
+    }
+
+    @Override
+    public WorkResult execute(final CopyActionProcessingStream dummy) {
+        final Path destinationGemFilePath = this.destinationGemFile.get().getAsFile().toPath();
+
+        try {
+            Files.createDirectories(destinationGemFilePath.getParent());
+            Files.deleteIfExists(destinationGemFilePath);
+            Files.move(this.sourceGemFilePath, destinationGemFilePath);
+        } catch (final IOException ex) {
+            throw new GradleException("Failed to locate the generated gem file at: " + destinationGemFilePath.toString(), ex);
+        }
+        return WorkResults.didWork(true);
+    }
+
+    private final Path sourceGemFilePath;
+    private final Provider<RegularFile> destinationGemFile;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import javax.inject.Inject;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.JavaExec;
+
+class GemPush extends JavaExec {
+    @Inject
+    public GemPush() {
+        super();
+
+        final ObjectFactory objectFactory = this.getProject().getObjects();
+        this.host = objectFactory.property(String.class);
+    }
+
+    @Override
+    public void exec() {
+        if ((!this.getHost().isPresent()) || this.getHost().get().isEmpty()) {
+            throw new GradleException("`host` must be specified in `gemPush`.");
+        }
+
+        final Project project = this.getProject();
+
+        // Looking up an appropriate jruby-complete JAR via the JRuby/Gradle plugin.
+        final Configuration jrubyExecConfiguration = project.getConfigurations().getByName("jrubyExec");
+        File jrubyCompleteFileFound = null;
+        for (final File file : jrubyExecConfiguration.getFiles()) {
+            if (file.getName().startsWith("jruby-complete")) {
+                if (jrubyCompleteFileFound == null) {
+                    jrubyCompleteFileFound = file;
+                } else {
+                    throw new GradleException("Multiple jruby-complete runtimes are found.");
+                }
+                break;
+            }
+        }
+
+        if (jrubyCompleteFileFound == null) {
+            throw new GradleException("No jruby-complete runtime is found.");
+        }
+        final File jrubyCompleteFile = jrubyCompleteFileFound;
+        project.getLogger().lifecycle("Using JRuby at: " + jrubyCompleteFile.toString());
+
+        final Gem gemTask = (Gem) project.getTasks().getByName("gem");
+        final File archiveFile = gemTask.getArchiveFile().get().getAsFile();
+
+        this.setWorkingDir(archiveFile.toPath().getParent().toFile());
+        this.setClasspath(project.files(jrubyCompleteFile));
+        this.setMain("org.jruby.Main");
+
+        final ArrayList<String> args = new ArrayList<>();
+        args.add("-rjars/setup");
+        args.add("-S");
+        args.add("gem");
+        args.add("push");
+        args.add(archiveFile.toString());
+        args.add("--verbose");
+        this.setArgs(args);
+
+        project.getLogger().lifecycle("Running: `java org.jruby.Main " + String.join(" ", args) + "`");
+
+        final HashMap<String, Object> environments = new HashMap<>();
+        environments.putAll(System.getenv());
+        environments.putAll(this.getEnvironment());
+        environments.put("RUBYGEMS_HOST", this.getHost().get());
+        this.setEnvironment(environments);
+
+        super.exec();
+    }
+
+    public Property<String> getHost() {
+        return this.host;
+    }
+
+    private final Property<String> host;
+}

--- a/src/test/resources/build.gradle
+++ b/src/test/resources/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
 embulkPlugin {
     mainClass = "org.embulk.input.test1.Test1InputPlugin"
+    category = "input"
+    type = "test1"
 }
 
 uploadArchives {


### PR DESCRIPTION
Updated again since #24. It adds features to relelase traditional `gem` style Embulk plugins. Then, it will be able to replace `build.gradle` of almost all the existing Java Embulk plugins.

Will release v0.2.1 of this plugin after this.

@sakama Can you have a quick look? Same as #24, just a quick look would be okay.