### PR TITLE
Fix syntax error in Embulk plugin gem's bootstrap Ruby code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.2.2-SNAPSHOT"
+version = "0.2.3-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -256,7 +256,7 @@ class Gem extends AbstractArchiveTask {
         final Path filePath = dirPath.resolve(this.embulkPluginType.get() + ".rb");
         try (final PrintWriter writer = new PrintWriter(Files.newOutputStream(filePath, StandardOpenOption.CREATE_NEW))) {
             writer.println("Embulk::JavaPlugin.register_" + this.embulkPluginCategory.get() + "(");
-            writer.println("  \"" + this.embulkPluginType.get() + "\", \"" + this.embulkPluginMainClass.get() + "\"");
+            writer.println("  \"" + this.embulkPluginType.get() + "\", \"" + this.embulkPluginMainClass.get() + "\",");
             writer.println("  File.expand_path(\"../../../../classpath\", __FILE__))");
         } catch (final IOException ex) {
             throw new GradleException("Could not create and write: " + filePath.toString(), ex);


### PR DESCRIPTION
Ugh, another silly bug since v0.2.1 (#25)... @sakama (Cc: @trung-huynh)

----

Fix syntax error in Embulk plugin gem's bootstrap Ruby code.
    
```
Embulk::JavaPlugin.register_input(
  "example", "org.embulk.input.example.ExampleInputPlugin",  # <= The last comma was missing
  File.expand_path("../../../../classpath", __FILE__))
```
