### PR TITLE
Load JRuby by itself without JRuby/Gradle, add notes in README.md, and bump up to v0.2.4-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.2.3-SNAPSHOT"
+version = "0.2.4-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -35,7 +35,8 @@ import org.gradle.api.provider.Property;
  *     mainClass = "org.embulk.input.example.ExampleInputPlugin"
  *     category = "input"
  *     type = "example"
- *     flatRuntimeConfiguration = "embulkPluginFlatRuntime"
+ *     flatRuntimeConfiguration = "embulkPluginFlatRuntime"  // Not recommended to configure it.
+ *     jruby = "org.jruby:jruby-complete:9.2.7.0"  // Not recommended to configure it.
  * }}</pre>
  */
 public class EmbulkPluginExtension {
@@ -48,6 +49,8 @@ public class EmbulkPluginExtension {
         this.type = objectFactory.property(String.class);
         this.flatRuntimeConfiguration = objectFactory.property(String.class);
         this.flatRuntimeConfiguration.set("embulkPluginFlatRuntime");
+        this.jruby = objectFactory.property(Object.class);
+        this.jruby.set("org.jruby:jruby-complete:9.2.7.0");
     }
 
     public Property<String> getMainClass() {
@@ -64,6 +67,13 @@ public class EmbulkPluginExtension {
 
     public Property<String> getFlatRuntimeConfiguration() {
         return this.flatRuntimeConfiguration;
+    }
+
+    /**
+     * Property to configure a dependency notation for JRuby to run `gem build` and `gem push` commands.
+     */
+    public Property<Object> getJruby() {
+        return this.jruby;
     }
 
     public void checkValidity() {
@@ -105,4 +115,5 @@ public class EmbulkPluginExtension {
     private final Property<String> category;
     private final Property<String> type;
     private final Property<String> flatRuntimeConfiguration;
+    private final Property<Object> jruby;
 }


### PR DESCRIPTION
This Gradle plugin has gotten a kind of working in v0.2.3 after #26 (v0.2.1), #27 (v0.2.2), and #28 (v0.2.3).

This PR #29 tries some cleanups, and loading JRuby by itself. (Until v0.2.3, it depended on the JRuby/Gradle plugin to load JRuby to run `gem`.)

@trung-huynh Can you have a look when you have time?