### PR TITLE
Move the `jruby` option to Gem and GemPush tasks, and clarify why they are not recommended to configure (Fix #32 and #33)

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -36,7 +36,6 @@ import org.gradle.api.provider.Property;
  *     category = "input"
  *     type = "example"
  *     flatRuntimeConfiguration = "embulkPluginFlatRuntime"  // Not recommended to configure it.
- *     jruby = "org.jruby:jruby-complete:9.2.7.0"  // Not recommended to configure it.
  * }}</pre>
  */
 public class EmbulkPluginExtension {
@@ -49,8 +48,6 @@ public class EmbulkPluginExtension {
         this.type = objectFactory.property(String.class);
         this.flatRuntimeConfiguration = objectFactory.property(String.class);
         this.flatRuntimeConfiguration.set("embulkPluginFlatRuntime");
-        this.jruby = objectFactory.property(Object.class);
-        this.jruby.set("org.jruby:jruby-complete:9.2.7.0");
     }
 
     public Property<String> getMainClass() {
@@ -67,13 +64,6 @@ public class EmbulkPluginExtension {
 
     public Property<String> getFlatRuntimeConfiguration() {
         return this.flatRuntimeConfiguration;
-    }
-
-    /**
-     * Property to configure a dependency notation for JRuby to run `gem build` and `gem push` commands.
-     */
-    public Property<Object> getJruby() {
-        return this.jruby;
     }
 
     public void checkValidity() {
@@ -115,5 +105,4 @@ public class EmbulkPluginExtension {
     private final Property<String> category;
     private final Property<String> type;
     private final Property<String> flatRuntimeConfiguration;
-    private final Property<Object> jruby;
 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -154,61 +154,47 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             final Project originalProject,
             final EmbulkPluginExtension extension,
             final Configuration runtimeConfiguration) {
-        if (extension.getJruby().isPresent() && extension.getJruby().get() != null && !extension.getJruby().get().equals("")) {
-            originalProject.getTasks().create("gem", Gem.class, task -> {
-                task.dependsOn("jar");
-            });
+        originalProject.getTasks().create("gem", Gem.class, task -> {
+            task.dependsOn("jar");
+        });
 
-            originalProject.getTasks().create("gemPush", GemPush.class, task -> {
-                task.dependsOn("gem");
-            });
+        originalProject.getTasks().create("gemPush", GemPush.class, task -> {
+            task.dependsOn("gem");
+        });
 
-            originalProject.afterEvaluate(project -> {
-                final Configuration jrubyConfiguration = project.getConfigurations().detachedConfiguration();
-                final Dependency jrubyDependency = project.getDependencies().create(extension.getJruby().get());
-                jrubyConfiguration.withDependencies(dependencies -> {
-                    dependencies.add(jrubyDependency);
+        originalProject.afterEvaluate(project -> {
+            project.getTasks().named("gem", Gem.class, task -> {
+                task.setEmbulkPluginMainClass(extension.getMainClass().get());
+                task.setEmbulkPluginCategory(extension.getCategory().get());
+                task.setEmbulkPluginType(extension.getType().get());
+
+                if ((!task.getArchiveBaseName().isPresent())) {
+                    // project.getName() never returns null.
+                    // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getName--
+                    task.getArchiveBaseName().set(project.getName());
+                }
+                // summary is kept empty -- mandatory.
+                if ((!task.getArchiveVersion().isPresent()) && (!project.getVersion().toString().equals("unspecified"))) {
+                    // project.getVersion() never returns null.
+                    // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getVersion--
+                    task.getArchiveVersion().set(buildGemVersionFromMavenVersion(project.getVersion().toString()));
+                }
+
+                if (!task.getGemDescription().isPresent() && project.getDescription() != null) {
+                    // project.getDescription() may return null.
+                    // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getDescription--
+                    task.getGemDescription().set(project.getDescription());
+                }
+
+                task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
+                task.from(runtimeConfiguration, copySpec -> {
+                    copySpec.into("classpath");
                 });
-
-                project.getTasks().named("gem", Gem.class, task -> {
-                    task.setJRubyConfiguration(jrubyConfiguration);
-
-                    task.setEmbulkPluginMainClass(extension.getMainClass().get());
-                    task.setEmbulkPluginCategory(extension.getCategory().get());
-                    task.setEmbulkPluginType(extension.getType().get());
-
-                    if ((!task.getArchiveBaseName().isPresent())) {
-                        // project.getName() never returns null.
-                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getName--
-                        task.getArchiveBaseName().set(project.getName());
-                    }
-                    // summary is kept empty -- mandatory.
-                    if ((!task.getArchiveVersion().isPresent()) && (!project.getVersion().toString().equals("unspecified"))) {
-                        // project.getVersion() never returns null.
-                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getVersion--
-                        task.getArchiveVersion().set(buildGemVersionFromMavenVersion(project.getVersion().toString()));
-                    }
-
-                    if (!task.getGemDescription().isPresent() && project.getDescription() != null) {
-                        // project.getDescription() may return null.
-                        // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getDescription--
-                        task.getGemDescription().set(project.getDescription());
-                    }
-
-                    task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
-                    task.from(runtimeConfiguration, copySpec -> {
-                        copySpec.into("classpath");
-                    });
-                    task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
-                        copySpec.into("classpath");
-                    });
-                });
-
-                project.getTasks().named("gemPush", GemPush.class, task -> {
-                    task.setJRubyConfiguration(jrubyConfiguration);
+                task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
+                    copySpec.into("classpath");
                 });
             });
-        }
+        });
     }
 
     private static String buildGemVersionFromMavenVersion(final String mavenVersion) {
@@ -241,4 +227,6 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             }
         }
     }
+
+    static final String DEFAULT_JRUBY = "org.jruby:jruby-complete:9.2.7.0";
 }


### PR DESCRIPTION
Not in a hurry. Can you have a look when you have time? @trung-huynh

It's just a kaizen. See #32 anf #33 for details.