### PR TITLE
Clear and set related environment variables before executing JRuby (Fix #31)

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -115,16 +115,21 @@ class Gem extends AbstractArchiveTask {
             final HashMap<String, Object> environments = new HashMap<>();
             environments.putAll(System.getenv());
             environments.putAll(javaExecSpec.getEnvironment());
-            /*
-            environments.put(
-                'JBUNDLE_SKIP' : true,
-                'JARS_SKIP' : true,
-                'PATH' : getComputedPATH(System.getenv().get(JRubyExecUtils.pathVar())),
-                'GEM_HOME' : getGemWorkDir().absolutePath,
-                'GEM_PATH' : getGemWorkDir().absolutePath,
-                'JARS_HOME' : new File(getGemWorkDir().absolutePath, 'jars'),
-                'JARS_LOCK' : new File(getGemWorkDir().absolutePath, 'Jars.lock')
-            */
+
+            // Clearing GEM_HOME and GEM_PATH so that user environment variables do not affect the gem execution.
+            environments.remove("GEM_HOME");
+            environments.remove("GEM_PATH");
+
+            // JARS_LOCK, JARS_HOME, and JARS_SKIP are for "jar-dependencies".
+            // https://github.com/mkristian/jar-dependencies/wiki/Jars.lock#jarslock-filename
+            environments.remove("JARS_LOCK");
+            // https://github.com/mkristian/jar-dependencies/blob/0.4.0/Readme.md#configuration
+            environments.remove("JARS_HOME");
+            environments.put("JARS_SKIP", "true");
+
+            // https://github.com/mkristian/jbundler/wiki/Configuration
+            environments.put("JBUNDLE_SKIP", "true");
+
             javaExecSpec.setEnvironment(environments);
         });
         execResult.assertNormalExitValue();

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
@@ -77,7 +77,24 @@ class GemPush extends JavaExec {
         final HashMap<String, Object> environments = new HashMap<>();
         environments.putAll(System.getenv());
         environments.putAll(this.getEnvironment());
+
+        // Clearing GEM_HOME and GEM_PATH so that user environment variables do not affect the gem execution.
+        environments.remove("GEM_HOME");
+        environments.remove("GEM_PATH");
+
+        // JARS_LOCK, JARS_HOME, and JARS_SKIP are for "jar-dependencies".
+        // https://github.com/mkristian/jar-dependencies/wiki/Jars.lock#jarslock-filename
+        environments.remove("JARS_LOCK");
+        // https://github.com/mkristian/jar-dependencies/blob/0.4.0/Readme.md#configuration
+        environments.remove("JARS_HOME");
+        environments.put("JARS_SKIP", "true");
+
+        // https://github.com/mkristian/jbundler/wiki/Configuration
+        environments.put("JBUNDLE_SKIP", "true");
+
+        // Set the RubyGems host for sure.
         environments.put("RUBYGEMS_HOST", this.getHost().get());
+
         this.setEnvironment(environments);
 
         super.exec();


### PR DESCRIPTION
Not in a hurry. Can you have a look when you have time? @trung-huynh

It is obvious that user environment variables `GEM_HOME` or `GEM_PATH` can cause problems in executing JRuby from this Gradle plugin. Clearing some other environment variables as well.