### PR TITLE
Make `gemPush` to be explicitly an incremental task, and non-JavaExec (Fix #34 / Fix #35)

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -36,7 +36,7 @@ import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.MavenPlugin;
-import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
@@ -206,7 +206,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
         });
 
         originalProject.afterEvaluate(project -> {
-            project.getTasks().named("gem", Gem.class, task -> {
+            final TaskProvider<Gem> gemTask = project.getTasks().named("gem", Gem.class, task -> {
                 task.setEmbulkPluginMainClass(extension.getMainClass().get());
                 task.setEmbulkPluginCategory(extension.getCategory().get());
                 task.setEmbulkPluginType(extension.getType().get());
@@ -236,6 +236,12 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                 task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
                     copySpec.into("classpath");
                 });
+            });
+
+            project.getTasks().named("gemPush", GemPush.class, task -> {
+                if (!task.getGem().isPresent()) {
+                    task.getGem().set(gemTask.get().getArchiveFile());
+                }
             });
         });
     }


### PR DESCRIPTION
Not in a hurry. Can you have a look when you have time? @trung-huynh

It makes the `gemPush` task an "incremental" task to check an update at the input `.gem` file. Otherwise, it was concerned that an old `.gem` file could be accedentally uploaded as a new version.
https://docs.gradle.org/current/userguide/custom_tasks.html#incremental_tasks

----

After this, #43, and fixing #36 at last, I believe this Gradle plugin will be ready to use. I think about starting to use this in some of our own plugins experimentally.