### PR TITLE
Retrieve `jruby` configurations appropriately (Fix a bug in #40)

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -119,7 +119,7 @@ class Gem extends AbstractArchiveTask {
         args.add(project.getName() + ".gemspec");
 
         final Configuration jrubyConfiguration = project.getConfigurations().detachedConfiguration();
-        final Dependency jrubyDependency = project.getDependencies().create(this.jruby);
+        final Dependency jrubyDependency = project.getDependencies().create(this.jruby.get());
         jrubyConfiguration.withDependencies(dependencies -> {
             dependencies.add(jrubyDependency);
         });

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
@@ -117,7 +117,7 @@ abstract class GemPush extends DefaultTask {
         args.add("--verbose");
 
         final Configuration jrubyConfiguration = project.getConfigurations().detachedConfiguration();
-        final Dependency jrubyDependency = project.getDependencies().create(this.jruby);
+        final Dependency jrubyDependency = project.getDependencies().create(this.jruby.get());
         jrubyConfiguration.withDependencies(dependencies -> {
             dependencies.add(jrubyDependency);
         });


### PR DESCRIPTION
A quick bug fix. It was just not working.