### PR TITLE
Change "embulkPluginFlatRuntime" to "embulkPluginRuntime", and to be non-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ embulkPlugin {
     type = "example"
 }
 
-// You can use any uploading mechanism as you like (e.g. `maven-publish`).
+// This Gradle plugin's POM dependency modification works only for Upload tasks.
+// Note that it does not work with "maven-publish" yet.
 uploadArchives {
     repositories {
         mavenDeployer {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -35,7 +35,6 @@ import org.gradle.api.provider.Property;
  *     mainClass = "org.embulk.input.example.ExampleInputPlugin"
  *     category = "input"
  *     type = "example"
- *     flatRuntimeConfiguration = "embulkPluginFlatRuntime"  // Not recommended to configure it.
  * }}</pre>
  */
 public class EmbulkPluginExtension {
@@ -46,8 +45,6 @@ public class EmbulkPluginExtension {
         this.mainClass = objectFactory.property(String.class);
         this.category = objectFactory.property(String.class);
         this.type = objectFactory.property(String.class);
-        this.flatRuntimeConfiguration = objectFactory.property(String.class);
-        this.flatRuntimeConfiguration.set("embulkPluginFlatRuntime");
     }
 
     public Property<String> getMainClass() {
@@ -60,10 +57,6 @@ public class EmbulkPluginExtension {
 
     public Property<String> getType() {
         return this.type;
-    }
-
-    public Property<String> getFlatRuntimeConfiguration() {
-        return this.flatRuntimeConfiguration;
     }
 
     void checkValidity() {
@@ -109,5 +102,4 @@ public class EmbulkPluginExtension {
     private final Property<String> mainClass;
     private final Property<String> category;
     private final Property<String> type;
-    private final Property<String> flatRuntimeConfiguration;
 }


### PR DESCRIPTION
Sorry, it turned out that #44 was not the last before available... ;)  @trung-huynh 

----

The configuration `flatRuntimeConfiguration` in `embulkPlugin` was not working.

Values of `EmbulkPluginExtension` (`embulkPlugin { ... }`) can be retrieved only in `afterEvaluate`. On the other hand, `conf2ScopeMappings` must be configured before evaluation (not in `afterEvaluate`). As a result, it is impossible to configure the Configuration name in `embulkPlugin`.

This commit gives up to configure it, and gives a fixed name `embulkPluginRuntime`. `flat` is removed there because the alternative configuration may have another purpose in the future.

In addition, it turned out that the POM dependency modification works only for `Upload` tasks, not in `maven-publish`, because `maven-publish` does not use `conf2ScopeMappings`.