### PR TITLE
Configure Travis-CI to build only for Pull Requests, or commits in the "master" branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,12 @@
 language: java
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+
+# Travis CI is to be configured to build both pushed branches and pull requests.
+# See: https://travis-ci.org/embulk/gradle-embulk-plugins/settings
+#
+# A pushed branch triggers a build only if it's the master branch.
+# A pushed pull request always triggers a build.
+branches:
+  only:
+  - master


### PR DESCRIPTION
It's not about the Gradle plugin by itself, but about its Travis-CI configuration to build.

By this, Travis-CI will build only for Pull Requests, and commits in the `master` branch.