### PR TITLE
Enable dependency locking by default in "embulkPluginRuntime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ uploadArchives {
 // }
 ```
 
+### Dependency locking
+
+The dependency configuration `embulkPluginRuntime`, which is added by this Gradle plugin for flattened dependencies, has [dependency locking](https://docs.gradle.org/current/userguide/dependency_locking.html) activated by default.
+
+In the beginning of your Embulk plugin project, it is recommended for you to run `./gradlew dependencies --write-locks`, and add generated `gradle/dependency-locks/embulkPluginRuntime.lockfile` in your version control system. Your Embulk plugin project will have more sensitive checks on its dependency libraries, then.
+
 ### How to migrate old-style `build.gradle` of your Embulk plugins
 
 1. Upgrade your Gradle wrapper to `5.5.1+`.

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -67,6 +67,10 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
         // It must be a non-detached configuration to be mapped into Maven scopes by Conf2ScopeMapping.
         final Configuration alternativeRuntimeConfiguration = project.getConfigurations().maybeCreate("embulkPluginRuntime");
 
+        // The "embulkPluginRuntime" configuration has dependency locking activated by default.
+        // https://docs.gradle.org/current/userguide/dependency_locking.html
+        alternativeRuntimeConfiguration.getResolutionStrategy().activateDependencyLocking();
+
         configureAlternativeRuntime(project, runtimeConfiguration, alternativeRuntimeConfiguration);
 
         // It must be configured before evaluation (not in afterEvaluate).
@@ -74,6 +78,9 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
 
         project.afterEvaluate(projectAfterEvaluate -> {
             initializeAfterEvaluate(projectAfterEvaluate, runtimeConfiguration, alternativeRuntimeConfiguration);
+
+            // Configuration#getResolvedConfiguration here so that the dependency lock state is checked.
+            alternativeRuntimeConfiguration.getResolvedConfiguration();
         });
     }
 


### PR DESCRIPTION
Then, it's really the last before releasing v0.2.4 of this Gradle plugin...!

It enables dependency locking in the `embulkPluginRuntime` configuration by default. The details are described in `README.md`.

