### PR TITLE
Use OpenJDK8 at Travis-CI, instead of Oracle JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
-# Travis CI is to be configured to build both pushed branches and pull requests.
+# Travis CI is to be configured to build only pushed branches, not pull requests.
 # See: https://travis-ci.org/embulk/gradle-embulk-plugins/settings
-#
-# A pushed branch triggers a build only if it's the master branch.
-# A pushed pull request always triggers a build.
-branches:
-  only:
-  - master

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.2.4-SNAPSHOT"
+version = "0.2.5-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {


### PR DESCRIPTION
Along with it, remove the branch restriction of Travis-CI, and bump up its own version to 0.2.5-SNAPSHOT.

@trung-huynh Can you have a look?

----

Oracle JDK8 installation started to fail.
* https://travis-ci.org/embulk/gradle-embulk-plugins/builds/568673056
* https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8

----

Removing the branch restriction (introduced in #47) because "A pushed pull request always triggers a build." was not true. A pull request for a non-`master` branch did not trigger Travis-CI.
```
To only build pull requests targeting specific branches you can use the branches: only: key, which will also restrict the branches that trigger builds.
```
https://docs.travis-ci.com/user/pull-requests#how-pull-requests-are-built
