### PR TITLE
Configure tasks that need "embulkPluginExtension" only when they are needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.2.5-SNAPSHOT"
+version = "0.2.6-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/ConfigureGemForEmbulkPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/ConfigureGemForEmbulkPlugin.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Jar;
+
+/**
+ * Configure a {@code "gem"} task to be available as an Embulk plugin.
+ */
+class ConfigureGemForEmbulkPlugin extends DefaultTask {
+    @Inject
+    public ConfigureGemForEmbulkPlugin() {
+        super();
+    }
+
+    @TaskAction
+    public void configure() {
+        final Project project = this.getProject();
+
+        final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
+
+        final Configuration runtimeConfiguration = project.getConfigurations().getByName("runtime");
+
+        final TaskProvider<Gem> gemTask = project.getTasks().named("gem", Gem.class, task -> {
+            task.setEmbulkPluginMainClass(extension.getMainClass().get());
+            task.setEmbulkPluginCategory(extension.getCategory().get());
+            task.setEmbulkPluginType(extension.getType().get());
+
+            if ((!task.getArchiveBaseName().isPresent())) {
+                // project.getName() never returns null.
+                // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getName--
+                task.getArchiveBaseName().set(project.getName());
+            }
+            // summary is kept empty -- mandatory.
+            if ((!task.getArchiveVersion().isPresent()) && (!project.getVersion().toString().equals("unspecified"))) {
+                // project.getVersion() never returns null.
+                // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getVersion--
+                task.getArchiveVersion().set(buildGemVersionFromMavenVersion(project.getVersion().toString()));
+            }
+
+            task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
+            task.from(runtimeConfiguration, copySpec -> {
+                copySpec.into("classpath");
+            });
+            task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
+                copySpec.into("classpath");
+            });
+        });
+
+        project.getTasks().named("gemPush", GemPush.class, task -> {
+            if (!task.getGem().isPresent()) {
+                task.getGem().set(gemTask.get().getArchiveFile());
+            }
+        });
+    }
+
+    private static String buildGemVersionFromMavenVersion(final String mavenVersion) {
+        if (mavenVersion.contains("-")) {
+            final List<String> versionTokens = Arrays.asList(mavenVersion.split("-"));
+            if (versionTokens.size() != 2) {
+                throw new GradleException("Failed to convert the version \"" + mavenVersion + "\" to Gem-style.");
+            }
+            return versionTokens.get(0) + '.' + versionTokens.get(1).toLowerCase();
+        } else {
+            return mavenVersion;
+        }
+    }
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/ConfigureJarForEmbulkPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/ConfigureJarForEmbulkPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.bundling.Jar;
+
+/**
+ * Configure a {@code "jar"} task to be available as an Embulk plugin.
+ *
+ * <p>It configures the {@code "jar"} task with required MANIFEST.
+ */
+public class ConfigureJarForEmbulkPlugin extends DefaultTask {
+    @Inject
+    public ConfigureJarForEmbulkPlugin() {
+        super();
+
+        final ObjectFactory objectFactory = this.getProject().getObjects();
+
+        this.jar = objectFactory.property(String.class);
+        this.jar.set("jar");
+    }
+
+    @TaskAction
+    public void configure() {
+        final Project project = this.getProject();
+
+        final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
+
+        project.getTasks().named(this.jar.get(), Jar.class, jarTask -> {
+            jarTask.manifest(UpdateManifestAction.builder()
+                             .add("Embulk-Plugin-Main-Class", extension.getMainClass().get())
+                             .add("Embulk-Plugin-Category", extension.getCategory().get())
+                             .add("Embulk-Plugin-Type", extension.getType().get())
+                             .add("Embulk-Plugin-Spi-Version", "0")
+                             .add("Implementation-Title", project.getName())
+                             .add("Implementation-Version", project.getVersion().toString())
+                             .build());
+        });
+    }
+
+    public Property<String> getJar() {
+        return this.jar;
+    }
+
+    private final Property<String> jar;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -59,7 +59,7 @@ public class EmbulkPluginExtension {
         return this.type;
     }
 
-    void checkValidity() {
+    boolean isValidEmbulkPluginDefined() {
         final ArrayList<String> errors = new ArrayList<>();
         if ((!this.mainClass.isPresent()) || this.mainClass.get().isEmpty()) {
             errors.add("\"mainClass\"");
@@ -71,17 +71,21 @@ public class EmbulkPluginExtension {
             errors.add("\"type\"");
         }
 
-        if (!errors.isEmpty()) {
-            throw new GradleException(
-                    "Failed to configure \"embulkPlugin\" because of insufficient settings: [ "
-                    + String.join(", ", errors) + " ]");
-        }
-
         if (!CATEGORIES.contains(this.category.get())) {
             throw new GradleException(
                     "Failed to configure \"embulkPlugin\" because \"category\" must be one of: [ "
                     + String.join(", ", CATEGORIES_ARRAY) + " ]");
         }
+
+        if (errors.isEmpty()) {
+            return true;
+        }
+
+        this.project.getLogger().lifecycle(
+                "The project \"{}\" is not configured for an Embulk plugin.", this.project.getPath());
+        this.project.getLogger().lifecycle(
+                "\"embulkPlugin { ... }\" is not fully configured. Insufficient setting(s): [ {} ]", String.join(", ", errors));
+        return false;
     }
 
     private static final String[] CATEGORIES_ARRAY = {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -16,20 +16,13 @@
 
 package org.embulk.gradle.embulk_plugins;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -38,10 +31,8 @@ import org.gradle.api.artifacts.maven.Conf2ScopeMapping;
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.MavenPlugin;
-import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
@@ -59,13 +50,6 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
         project.getPluginManager().apply(MavenPlugin.class);
 
         final EmbulkPluginExtension extension = createExtension(project);
-
-        project.getTasks().create("gem", Gem.class, task -> {
-            task.dependsOn("jar");
-        });
-        project.getTasks().create("gemPush", GemPush.class, task -> {
-            task.dependsOn("gem");
-        });
 
         final Configuration runtimeConfiguration = project.getConfigurations().getByName("runtime");
 
@@ -120,13 +104,41 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             final Configuration alternativeRuntimeConfiguration) {
         final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
 
-        extension.checkValidity();
+        if (!extension.isValidEmbulkPluginDefined()) {
+            return;
+        }
 
-        configureJarTask(project, extension);
+        project.getTasks().create("configureJarForEmbulkPlugin", ConfigureJarForEmbulkPlugin.class, task -> {
+            task.setGroup(EMBULK_PLUGIN_GROUP);
+            task.setDescription("Configures the 'jar' task to be available as an Embulk plugin.");
+        });
 
-        warnIfRuntimeHasCompileOnlyDependencies(project, alternativeRuntimeConfiguration);
+        final WarnIfRuntimeHasCompileOnlyDependencies warnTask = project.getTasks().create(
+                "warnIfRuntimeHasCompileOnlyDependencies",
+                WarnIfRuntimeHasCompileOnlyDependencies.class,
+                alternativeRuntimeConfiguration);
+        warnTask.setGroup(EMBULK_PLUGIN_GROUP);
+        warnTask.setDescription("Checks if compileOnly's transitive dependencies are included in runtime.");
 
-        configureGemTasks(project, extension, runtimeConfiguration);
+        project.getTasks().named("jar", Jar.class, task -> {
+            task.dependsOn("configureJarForEmbulkPlugin");
+            task.dependsOn("warnIfRuntimeHasCompileOnlyDependencies");
+        });
+
+        project.getTasks().create("configureGemForEmbulkPlugin", ConfigureGemForEmbulkPlugin.class, task -> {
+            task.setDescription("Configures the 'gem' task before executing it.");
+        });
+        project.getTasks().create("gem", Gem.class, task -> {
+            task.dependsOn("jar");
+            task.dependsOn("configureGemForEmbulkPlugin");
+            task.setGroup(EMBULK_PLUGIN_GEM_GROUP);
+            task.setDescription("Assembles a gem archive as an Embulk plugin.");
+        });
+        project.getTasks().create("gemPush", GemPush.class, task -> {
+            task.dependsOn("gem");
+            task.setGroup(EMBULK_PLUGIN_GEM_GROUP);
+            task.setDescription("Pushes the gem archive.");
+        });
     }
 
     /**
@@ -158,7 +170,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                         }
                     }
                 } else {
-                    recurseAllDependencies(dependency, allDependencies);
+                    Util.recurseAllDependencies(dependency, allDependencies);
                 }
             }
 
@@ -205,141 +217,8 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                                               Conf2ScopeMappingContainer.RUNTIME);
     }
 
-    /**
-     * Configures the standard {@code "jar"} task with required MANIFEST.
-     */
-    private static void configureJarTask(final Project project, final EmbulkPluginExtension extension) {
-        project.getTasks().named("jar", Jar.class, jarTask -> {
-            jarTask.manifest(UpdateManifestAction.builder()
-                             .add("Embulk-Plugin-Main-Class", extension.getMainClass().get())
-                             .add("Embulk-Plugin-Category", extension.getCategory().get())
-                             .add("Embulk-Plugin-Type", extension.getType().get())
-                             .add("Embulk-Plugin-Spi-Version", "0")
-                             .add("Implementation-Title", project.getName())
-                             .add("Implementation-Version", project.getVersion().toString())
-                             .build());
-        });
-    }
-
-    private static void warnIfRuntimeHasCompileOnlyDependencies(
-            final Project project,
-            final Configuration alternativeRuntimeConfiguration) {
-        final Configuration compileOnlyConfiguration = project.getConfigurations().getByName("compileOnly");
-
-        final Map<String, ResolvedDependency> compileOnlyDependencies =
-                collectAllDependencies(compileOnlyConfiguration);
-        final Map<String, ResolvedDependency> alternativeRuntimeDependencies =
-                collectAllDependencies(alternativeRuntimeConfiguration);
-
-        final Set<String> intersects = new HashSet<>();
-        intersects.addAll(alternativeRuntimeDependencies.keySet());
-        intersects.retainAll(compileOnlyDependencies.keySet());
-        if (!intersects.isEmpty()) {
-            final Logger logger = project.getLogger();
-
-            // Logging in the "error" loglevel to show the severity, but not to fail with GradleException.
-            logger.error(
-                    "============================================ WARNING ============================================\n"
-                    + "Following \"runtime\" dependencies are included also in \"compileOnly\" dependencies.\n"
-                    + "\n"
-                    + intersects.stream().map(key -> {
-                          final ResolvedDependency dependency = alternativeRuntimeDependencies.get(key);
-                          return "  \"" + dependency.getModule().toString() + "\"\n";
-                      }).collect(Collectors.joining(""))
-                    + "\n"
-                    + "  \"compileOnly\" dependencies are used to represent Embulk's core to be \"provided\" at runtime.\n"
-                    + "  They should be excluded from \"compile\" or \"runtime\" dependencies like the example below.\n"
-                    + "\n"
-                    + "  dependencies {\n"
-                    + "    compile(\"org.glassfish.jersey.core:jersey-client:2.25.1\") {\n"
-                    + "      exclude group: \"javax.inject\", module: \"javax.inject\"\n"
-                    + "    }\n"
-                    + "  }\n"
-                    + "=================================================================================================");
-        }
-    }
-
-    private static void configureGemTasks(
-            final Project project,
-            final EmbulkPluginExtension extension,
-            final Configuration runtimeConfiguration) {
-        final TaskProvider<Gem> gemTask = project.getTasks().named("gem", Gem.class, task -> {
-            task.setEmbulkPluginMainClass(extension.getMainClass().get());
-            task.setEmbulkPluginCategory(extension.getCategory().get());
-            task.setEmbulkPluginType(extension.getType().get());
-
-            if ((!task.getArchiveBaseName().isPresent())) {
-                // project.getName() never returns null.
-                // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getName--
-                task.getArchiveBaseName().set(project.getName());
-            }
-            if ((!task.getArchiveClassifier().isPresent()) || task.getArchiveClassifier().get().isEmpty()) {
-                task.getArchiveClassifier().set("java");
-            }
-            // summary is kept empty -- mandatory.
-            if ((!task.getArchiveVersion().isPresent()) && (!project.getVersion().toString().equals("unspecified"))) {
-                // project.getVersion() never returns null.
-                // https://docs.gradle.org/5.5.1/javadoc/org/gradle/api/Project.html#getVersion--
-                task.getArchiveVersion().set(buildGemVersionFromMavenVersion(project.getVersion().toString()));
-            }
-
-            task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
-            task.from(runtimeConfiguration, copySpec -> {
-                copySpec.into("classpath");
-            });
-            task.from(((Jar) project.getTasks().getByName("jar")).getArchiveFile(), copySpec -> {
-                copySpec.into("classpath");
-            });
-        });
-
-        project.getTasks().named("gemPush", GemPush.class, task -> {
-            if (!task.getGem().isPresent()) {
-                task.getGem().set(gemTask.get().getArchiveFile());
-            }
-        });
-    }
-
-    private static String buildGemVersionFromMavenVersion(final String mavenVersion) {
-        if (mavenVersion.contains("-")) {
-            final List<String> versionTokens = Arrays.asList(mavenVersion.split("-"));
-            if (versionTokens.size() != 2) {
-                throw new GradleException("Failed to convert the version \"" + mavenVersion + "\" to Gem-style.");
-            }
-            return versionTokens.get(0) + '.' + versionTokens.get(1).toLowerCase();
-        }
-        else {
-            return mavenVersion;
-        }
-    }
-
-    private static Map<String, ResolvedDependency> collectAllDependencies(final Configuration configuration) {
-        final HashMap<String, ResolvedDependency> allDependencies = new HashMap<>();
-
-        final Set<ResolvedDependency> firstLevel = configuration.getResolvedConfiguration().getFirstLevelModuleDependencies();
-        for (final ResolvedDependency dependency : firstLevel) {
-            recurseAllDependencies(dependency, allDependencies);
-        }
-
-        return Collections.unmodifiableMap(allDependencies);
-    }
-
-    /**
-     * Traverses the dependency tree recursively to list all the dependencies.
-     */
-    private static void recurseAllDependencies(
-            final ResolvedDependency dependency,
-            final Map<String, ResolvedDependency> allDependencies) {
-        final String key = dependency.getModuleGroup() + ":" + dependency.getModuleName();
-        if (allDependencies.containsKey(key)) {
-            return;
-        }
-        allDependencies.put(key, dependency);
-        if (dependency.getChildren().size() > 0) {
-            for (final ResolvedDependency child : dependency.getChildren()) {
-                recurseAllDependencies(child, allDependencies);
-            }
-        }
-    }
-
     static final String DEFAULT_JRUBY = "org.jruby:jruby-complete:9.2.7.0";
+
+    private static final String EMBULK_PLUGIN_GROUP = "Embulk plugin";
+    private static final String EMBULK_PLUGIN_GEM_GROUP = "Embulk plugin Gem";
 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/Util.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Util.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.util.Map;
+import org.gradle.api.artifacts.ResolvedDependency;
+
+class Util {
+    private Util() {
+        // No instantiation.
+    }
+
+    /**
+     * Traverses the dependency tree recursively to list all the dependencies.
+     */
+    static void recurseAllDependencies(
+            final ResolvedDependency dependency,
+            final Map<String, ResolvedDependency> allDependencies) {
+        final String key = dependency.getModuleGroup() + ":" + dependency.getModuleName();
+        if (allDependencies.containsKey(key)) {
+            return;
+        }
+        allDependencies.put(key, dependency);
+        if (dependency.getChildren().size() > 0) {
+            for (final ResolvedDependency child : dependency.getChildren()) {
+                recurseAllDependencies(child, allDependencies);
+            }
+        }
+    }
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/WarnIfRuntimeHasCompileOnlyDependencies.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/WarnIfRuntimeHasCompileOnlyDependencies.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.TaskAction;
+
+class WarnIfRuntimeHasCompileOnlyDependencies extends DefaultTask {
+    @Inject
+    public WarnIfRuntimeHasCompileOnlyDependencies(final Configuration alternativeRuntimeConfiguration) {
+        super();
+        this.alternativeRuntimeConfiguration = alternativeRuntimeConfiguration;
+    }
+
+    @TaskAction
+    public void warn() {
+        final Project project = this.getProject();
+
+        final Configuration compileOnlyConfiguration = project.getConfigurations().getByName("compileOnly");
+
+        final Map<String, ResolvedDependency> compileOnlyDependencies =
+                collectAllDependencies(compileOnlyConfiguration);
+        final Map<String, ResolvedDependency> alternativeRuntimeDependencies =
+                collectAllDependencies(this.alternativeRuntimeConfiguration);
+
+        final Set<String> intersects = new HashSet<>();
+        intersects.addAll(alternativeRuntimeDependencies.keySet());
+        intersects.retainAll(compileOnlyDependencies.keySet());
+        if (!intersects.isEmpty()) {
+            final Logger logger = project.getLogger();
+
+            // Logging in the "error" loglevel to show the severity, but not to fail with GradleException.
+            logger.error(
+                    "============================================ WARNING ============================================\n"
+                    + "Following \"runtime\" dependencies are included also in \"compileOnly\" dependencies.\n"
+                    + "\n"
+                    + intersects.stream().map(key -> {
+                        final ResolvedDependency dependency = alternativeRuntimeDependencies.get(key);
+                        return "  \"" + dependency.getModule().toString() + "\"\n";
+                    }).collect(Collectors.joining(""))
+                    + "\n"
+                    + "  \"compileOnly\" dependencies are used to represent Embulk's core to be \"provided\" at runtime.\n"
+                    + "  They should be excluded from \"compile\" or \"runtime\" dependencies like the example below.\n"
+                    + "\n"
+                    + "  dependencies {\n"
+                    + "    compile(\"org.glassfish.jersey.core:jersey-client:2.25.1\") {\n"
+                    + "      exclude group: \"javax.inject\", module: \"javax.inject\"\n"
+                    + "    }\n"
+                    + "  }\n"
+                    + "=================================================================================================");
+        }
+    }
+
+    private static Map<String, ResolvedDependency> collectAllDependencies(final Configuration configuration) {
+        final HashMap<String, ResolvedDependency> allDependencies = new HashMap<>();
+
+        final Set<ResolvedDependency> firstLevel = configuration.getResolvedConfiguration().getFirstLevelModuleDependencies();
+        for (final ResolvedDependency dependency : firstLevel) {
+            Util.recurseAllDependencies(dependency, allDependencies);
+        }
+
+        return Collections.unmodifiableMap(allDependencies);
+    }
+
+    private final Configuration alternativeRuntimeConfiguration;
+}


### PR DESCRIPTION
"EmbulkPluginExtension" has been always validated when running Gradle so that
the "jar" and "gem" tasks can use the extension values.

The validation has been sometimes annoying, however. For example, just running
"./gradlew wrapper --gradle-version=5.6" does not work if "build.gradle" does
not contain "embulkPlugin { ... }" configured properly.

This commit makes the validation lazy so that it works only when the "jar" or
"gem" tasks are executed, by externaizing the initializer methods into separate
tasks, and getting them executed by the "dependsOn" mechanism of Gradle.

It adds task groups and descriptions, and bumps up to 0.2.6-SNAPSHOT along with
the change.
