### PR TITLE
Set the "embulkPluginRuntime" configuration non-transitive (Fix #59)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.2.5-SNAPSHOT"
+version = "0.2.6-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 repositories {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -136,6 +136,23 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             final Project project,
             final Configuration runtimeConfiguration,
             final Configuration alternativeRuntimeConfiguration) {
+        // The "embulkPluginRuntime" configuration do not need to be transitive, and must be non-transitive.
+        //
+        // It contains all transitive dependencies of "runtime" flattened. It does not need to be transitive, then.
+        // Moreover, setting it transitive troubles the warning shown by |warnIfRuntimeHasCompileOnlyDependencies|.
+        //
+        // The Embulk plugin developer may explicitly exclude some transitive dependencies as below :
+        //
+        //   dependencies {
+        //       compile("org.glassfish.jersey.core:jersey-client:2.25.1") {
+        //           exclude group: "javax.inject", module: "javax.inject"
+        //       }
+        //   }
+        //
+        // If "embulkPluginRuntime" is still transitive, it would finally contain "javax.inject:javax.inject".
+        // The behavior is unintended. So, "embulkPluginRuntime" must be non-transitive.
+        alternativeRuntimeConfiguration.setTransitive(false);
+
         alternativeRuntimeConfiguration.withDependencies(dependencies -> {
             final Map<String, ResolvedDependency> allDependencies = new HashMap<>();
             final Set<ResolvedDependency> firstLevelDependencies =

--- a/src/test/resources/build2.gradle
+++ b/src/test/resources/build2.gradle
@@ -1,0 +1,58 @@
+plugins {
+    id "java"
+    id "maven"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+group = "org.embulk.input.test2"
+archivesBaseName = "${project.name}"
+version = "0.1.9"
+description = "Embulk input plugin for testing 2"
+
+repositories {
+    jcenter()
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.17"
+    compile("org.glassfish.jersey.core:jersey-client:2.25.1") {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test1.Test1InputPlugin"
+    category = "input"
+    type = "test1"
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            repository(url: "file:${project.buildDir}/mavenLocal")
+            snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
+        }
+    }
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${project.buildDir}/mavenPublishLocal"
+        }
+    }
+}


### PR DESCRIPTION
The "embulkPluginRuntime" configuration do not need to be transitive, and must be non-transitive.

It contains all transitive dependencies of "runtime" flattened. It does not need to be transitive, then.
Moreover, setting it transitive troubles the warning shown by `warnIfRuntimeHasCompileOnlyDependencies`.

An Embulk plugin developer may explicitly exclude some transitive dependencies as below :

```
  dependencies {
      compile("org.glassfish.jersey.core:jersey-client:2.25.1") {
          exclude group: "javax.inject", module: "javax.inject"
      }
  }
```

If "embulkPluginRuntime" is still transitive, it would finally contain "javax.inject:javax.inject".
The behavior is unintended. So, "embulkPluginRuntime" must be non-transitive.