### PR TITLE
Make "mainJar" configurable so that another task than the normal "jar" task

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -35,6 +35,7 @@ import org.gradle.api.provider.Property;
  *     mainClass = "org.embulk.input.example.ExampleInputPlugin"
  *     category = "input"
  *     type = "example"
+ *     // mainJar = "shadowJar"
  * }}</pre>
  */
 public class EmbulkPluginExtension {
@@ -45,6 +46,7 @@ public class EmbulkPluginExtension {
         this.mainClass = objectFactory.property(String.class);
         this.category = objectFactory.property(String.class);
         this.type = objectFactory.property(String.class);
+        this.mainJar = objectFactory.property(String.class);
     }
 
     public Property<String> getMainClass() {
@@ -57,6 +59,10 @@ public class EmbulkPluginExtension {
 
     public Property<String> getType() {
         return this.type;
+    }
+
+    public Property<String> getMainJar() {
+        return this.mainJar;
     }
 
     void checkValidity() {
@@ -102,4 +108,5 @@ public class EmbulkPluginExtension {
     private final Property<String> mainClass;
     private final Property<String> category;
     private final Property<String> type;
+    private final Property<String> mainJar;
 }

--- a/src/test/resources/build3.gradle
+++ b/src/test/resources/build3.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id "java"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+group = "org.embulk.input.test3"
+archivesBaseName = "${project.name}"
+version = "0.2.8"
+description = "Embulk input plugin for testing 3"
+
+repositories {
+    jcenter()
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.17"
+    compile "javax.json:javax.json-api:1.1.4"
+}
+
+task specialJar(type: Jar) {
+    from configurations.compile.collect { zipTree it }
+    manifest {
+        attributes "Foo": "Bar"
+    }
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test3.Test3InputPlugin"
+    category = "input"
+    type = "test3"
+    mainJar = "specialJar"
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            artifact specialJar
+        }
+    }
+    repositories {
+        maven {
+            url = "${project.buildDir}/mavenLocal3"
+        }
+    }
+}


### PR DESCRIPTION
Some Embulk plugins need to embed its dependency libraries in itself, possibly with renaming/relocating their packages, for example with the "shadow" Gradle plugin.
https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow

The "shadow" Gradle plugin creates another "shadowJar" task in addition to the default "jar" task. But, this "org.embulk.embulk-plugins" Gradle plugin accepted only the default "jar" task. It couldn't be used with the "shadow" Gradle plugin.

This change would mitigate the situation. It allows Embulk plugin developers to build an Embulk plugin with the "shadow" Gradle plugin. It requires "build.gradle" to be a little bit non-intuitive, though.