### PR TITLE
Unsupport "uploadArchives" with the "maven" plugin to delay creating the "embulkPluginRuntime" configuration after evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Quick Guide
 ```
 plugins {
     id "java"
-    id "maven"  // To release with upload (uploadArchives).
-    id "maven-publish"  // To release with publishing.
+    id "maven-publish"  // Note that "uploadArchives" with the "maven" plugin is no longer supported.
 
     // Once this Gradle plugin is applied, its transitive dependencies are automatically updated to be flattened.
     // The update affects the default `jar` task, and default Maven uploading mechanisms as well.
-    id "org.embulk.embulk-plugins" version "0.2.7"
+    id "org.embulk.embulk-plugins" version "0.3.0"
 }
 
 group = "com.example"
@@ -44,17 +43,10 @@ embulkPlugin {
     type = "example"
 }
 
-// This Gradle plugin's POM dependency modification works for Upload tasks.
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: "file:${project.buildDir}/mavenLocal")
-            snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
-        }
-    }
-}
-
 // This Gradle plugin's POM dependency modification works for "maven-publish" tasks.
+//
+// Note that "uploadArchives" is no longer supported. It is deprecated in Gradle 6 to be removed in Gradle 7.
+// https://github.com/gradle/gradle/issues/3003#issuecomment-495025844
 publishing {
     publications {
         embulkPluginMaven(MavenPublication) {  // Publish it with "publishEmbulkPluginMavenPublicationToMavenRepository".
@@ -224,7 +216,7 @@ In the beginning of your Embulk plugin project, it is recommended for you to run
     * Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
       ```
       plugins {
-          id "org.embulk.embulk-plugins" version "0.2.7"
+          id "org.embulk.embulk-plugins" version "0.3.0"
       }
     * Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
       ```
@@ -235,7 +227,7 @@ In the beginning of your Embulk plugin project, it is recommended for you to run
           }
       }
       dependencies {
-          classpath "gradle.plugin.org.embulk:gradle-embulk-plugins:0.2.7"
+          classpath "gradle.plugin.org.embulk:gradle-embulk-plugins:0.3.0"
       }
 
       apply plugin: "org.embulk.embulk-plugins"
@@ -259,17 +251,7 @@ In the beginning of your Embulk plugin project, it is recommended for you to run
     }
 11. Configure publishing the plugin JAR to the Maven repository where you want to upload.
     * The standard `jar` task is already reconfigured to generate a JAR ready as an Embulk plugin.
-    * Publishing example with `uploadArchives`:
-    ```
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                repository(url: "file:${project.buildDir}/mavenLocal")
-                snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
-            }
-        }
-    }
-    ```
+    * Note that `uploadArchives` with the `maven` plugin is no longer supported.
     * Publishing example with `maven-publish`:
     ```
     publishing {

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
@@ -52,25 +52,6 @@ import org.xml.sax.SAXException;
 
 class TestEmbulkPluginsPlugin {
     @Test
-    public void testUpload(@TempDir Path tempDir) throws IOException {
-        final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test1"));
-        Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build.gradle"),
-                   projectDir.resolve("build.gradle"));
-
-        this.build(projectDir, "jar");
-        assertTrue(Files.exists(projectDir.resolve("build/libs/embulk-input-test1-0.2.5.jar")));
-
-        this.build(projectDir, "uploadArchives");
-        final Path versionDir = projectDir.resolve("build/mavenLocal/org/embulk/input/test1/embulk-input-test1/0.2.5");
-        final Path jarPath = versionDir.resolve("embulk-input-test1-0.2.5.jar");
-        final Path pomPath = versionDir.resolve("embulk-input-test1-0.2.5.pom");
-        assertTrue(Files.exists(jarPath));
-        assertManifest(jarPath);
-        assertTrue(Files.exists(pomPath));
-        assertPom(pomPath);
-    }
-
-    @Test
     public void testPublish(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test1"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build.gradle"),

--- a/src/test/resources/build.gradle
+++ b/src/test/resources/build.gradle
@@ -33,15 +33,6 @@ embulkPlugin {
     type = "test1"
 }
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: "file:${project.buildDir}/mavenLocal")
-            snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
-        }
-    }
-}
-
 publishing {
     publications {
         embulkPluginMaven(MavenPublication) {

--- a/src/test/resources/build2.gradle
+++ b/src/test/resources/build2.gradle
@@ -35,15 +35,6 @@ embulkPlugin {
     type = "test1"
 }
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: "file:${project.buildDir}/mavenLocal")
-            snapshotRepository(url: "file:${project.buildDir}/mavenLocalSnapshot")
-        }
-    }
-}
-
 publishing {
     publications {
         embulkPluginMaven(MavenPublication) {


### PR DESCRIPTION
The `embulkPluginRuntime` configuration needs to be configured after evaluation so that it can have an Attribute to work with Gradle 6. See #71 for the details.

At the same time, Gradle started to deprecate `uploadArchives` with the `maven` plugin from Gradle 6 to be possibly removed in Gradle 7. It's good time to stop supporting `uploadArchives` even in this Gradle plugin.
https://github.com/gradle/gradle/issues/3003#issuecomment-495025844