### PR TITLE
Make gem dependencies, auto-genarated bootstrap Ruby code, and auto-generated gemspec configurable (Fix #68)

### DIFF
--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
@@ -118,6 +118,25 @@ class TestEmbulkPluginsPlugin {
         assertPom3(pomPath);
     }
 
+    @Test
+    public void testNoGenerateRubyCode(@TempDir Path tempDir) throws IOException {
+        final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test4"));
+        Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build4.gradle"),
+                   projectDir.resolve("build.gradle"));
+        Files.createDirectories(projectDir.resolve("lib/embulk/input/"));
+        Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("lib/embulk/input/test4.rb"),
+                   projectDir.resolve("lib/embulk/input/test4.rb"));
+
+        this.build(projectDir, "gem");
+        assertTrue(Files.exists(projectDir.resolve("build/libs/embulk-input-test4-0.9.2.jar")));
+        assertTrue(Files.exists(projectDir.resolve("build/gemContents/lib/embulk/input/test4.rb")));
+
+        final List<String> lines = Files.readAllLines(
+                projectDir.resolve("build/gemContents/lib/embulk/input/test4.rb"), StandardCharsets.UTF_8);
+        assertEquals(1, lines.size());
+        assertEquals("puts \"test\"", lines.get(0));
+    }
+
     private static BuildResult build(final Path projectDir, final String... args) {
         final ArrayList<String> argsList = new ArrayList<>();
         argsList.addAll(Arrays.asList(args));

--- a/src/test/resources/build4.gradle
+++ b/src/test/resources/build4.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id "java"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+group = "org.embulk.input.test4"
+archivesBaseName = "${project.name}"
+version = "0.9.2"
+description = "Embulk input plugin for testing 4"
+
+repositories {
+    jcenter()
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.17"
+    compile "javax.json:javax.json-api:1.1.4"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test4.Test4InputPlugin"
+    category = "input"
+    type = "test4"
+}
+
+gem {
+    authors = [ "Somebody" ]
+    email = [ "somebody@example.com" ]
+    summary = "Dummy"
+    homepage = ""
+    licenses = [ ""]
+
+    generateRubyCode = false
+    into("lib/embulk/input/") {
+        from "lib/embulk/input/test4.rb"
+    }
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${project.buildDir}/mavenLocal4"
+        }
+    }
+}

--- a/src/test/resources/lib/embulk/input/test4.rb
+++ b/src/test/resources/lib/embulk/input/test4.rb
@@ -1,0 +1,1 @@
+puts "test"


### PR DESCRIPTION
Some Embulk plugins need non-default bootstrap Ruby code. Some need additional gem dependencies. To support such cases, this change introduces additional configurations like below.

```
gem {
    // ...
    generateRubyCode = false
    from "/lib/embulk/input/example.rb"  // Developer's own bootstrap Ruby code, not auto-generated
    dependencies = [ "'json', ['~> 2.0.2']" ]
}
```
