### PR TITLE
Work with hyphenated version numbers like 1.2.3-SNAPSHOT (Fix #80)

### DIFF
--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
@@ -136,6 +136,17 @@ class TestEmbulkPluginsPlugin {
         assertEquals("puts \"test\"", lines.get(0));
     }
 
+    @Test
+    public void testRubyVersion(@TempDir Path tempDir) throws IOException {
+        final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test5"));
+        Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build5.gradle"),
+                   projectDir.resolve("build.gradle"));
+
+        this.build(projectDir, "gem");
+        assertTrue(Files.exists(projectDir.resolve("build/libs/embulk-input-test5-0.1.41-SNAPSHOT.jar")));
+        assertTrue(Files.exists(projectDir.resolve("build/gems/embulk-input-test5-0.1.41.snapshot-java.gem")));
+    }
+
     private static BuildResult build(final Path projectDir, final String... args) {
         final ArrayList<String> argsList = new ArrayList<>();
         argsList.addAll(Arrays.asList(args));

--- a/src/test/resources/build5.gradle
+++ b/src/test/resources/build5.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id "java"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+group = "org.embulk.input.test5"
+archivesBaseName = "${project.name}"
+version = "0.1.41-SNAPSHOT"
+description = "Embulk input plugin for testing 5"
+
+repositories {
+    jcenter()
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.17"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test5.Test5InputPlugin"
+    category = "input"
+    type = "test5"
+}
+
+gem {
+    authors = [ "Somebody" ]
+    email = [ "somebody@example.com" ]
+    summary = "Dummy"
+    homepage = ""
+    licenses = [ ""]
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${project.buildDir}/mavenLocal5"
+        }
+    }
+}


### PR DESCRIPTION
As issued in #80, hyphenated version numbers like `1.2.3-SNAPSHOT` did not work because this style does not work as a Ruby gem.

As a common manner, it translates Java-style version numbers (`1.2.3-SNAPSHOT`) to Ruby-style version numbers (`1.2.3.snapshot`).