### PR TITLE
Support project dependencies like `implementation project(":subproject")` (Fix #54)

### DIFF
--- a/src/test/resources/subprojects/build_root.gradle
+++ b/src/test/resources/subprojects/build_root.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id "java"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+allprojects {
+    group = "org.embulk.input.test_subprojects"
+    version = "0.6.14"
+}
+archivesBaseName = "${project.name}"
+description = "Embulk input plugin for testing subprojects root"
+
+repositories {
+    jcenter()
+}
+
+allprojects {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+
+    tasks.withType(JavaCompile) {
+        options.encoding = "UTF-8"
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    }
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.23"
+    compile project(":sublib")
+    compile "commons-io:commons-io:2.6"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test_subprojects.SubprojectsRootInputPlugin"
+    category = "input"
+    type = "test_subprojects_root"
+}
+
+gem {
+    authors = [ "Somebody" ]
+    email = [ "somebody@example.com" ]
+    summary = "Dummy"
+    homepage = ""
+    licenses = [ "" ]
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${rootProject.buildDir}/mavenLocalSubprojects"
+        }
+    }
+}

--- a/src/test/resources/subprojects/build_sublib.gradle
+++ b/src/test/resources/subprojects/build_sublib.gradle
@@ -1,0 +1,26 @@
+apply plugin: "java"
+apply plugin: "maven-publish"
+
+archivesBaseName = "${project.name}"
+description = "Sub-library for testing subproject"
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile "commons-lang:commons-lang:2.6"
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${rootProject.buildDir}/mavenLocalSubprojects"
+        }
+    }
+}

--- a/src/test/resources/subprojects/build_subplugin.gradle
+++ b/src/test/resources/subprojects/build_subplugin.gradle
@@ -1,0 +1,43 @@
+apply plugin: "java"
+apply plugin: "maven-publish"
+apply plugin: "org.embulk.embulk-plugins"
+
+archivesBaseName = "${project.name}"
+description = "Embulk input plugin for testing subproject sub"
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-core:0.9.23"
+    compile project(":sublib")
+    compile "org.apache.commons:commons-math3:3.6.1"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.test_subprojects.SubprojectsSubInputPlugin"
+    category = "input"
+    type = "test_subprojects_sub"
+}
+
+gem {
+    authors = [ "Somebody" ]
+    email = [ "somebody@example.com" ]
+    summary = "Dummy"
+    homepage = ""
+    licenses = [ "" ]
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${rootProject.buildDir}/mavenLocalSubprojects"
+        }
+    }
+}

--- a/src/test/resources/subprojects/settings.gradle
+++ b/src/test/resources/subprojects/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = "embulk-input-subprojects_root"
+include "sublib"
+include "embulk-input-subprojects_subplugin"


### PR DESCRIPTION
See #52 and #54 for the details.

Embulk plugin projects have failed if they use `project(":subproject")` with this Gradle plugin. If was because this Gradle plugin was trying to iterate all transitive dependencies, and re-add them just with their module names like `"com.example:module:0.1.2"`.

This PR changes the behavior to check the iterated dependency is from module, or project dependencies.

Because we have some unknown situations (e.g. `LibraryBinaryIdentifier`, and multiple artifacts in a dependency). Trying to print noisy logs for them.