### PR TITLE
Support project dependencies with configuration like `implementation project(path: ":subproject", configuration: "shadow")` (Fix #82)

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -169,6 +169,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             }
 
             for (final ResolvedDependency dependency : allDependencies.values()) {
+                final String dependencyConfiguration = dependency.getConfiguration();
                 final Set<ResolvedArtifact> moduleArtifacts = dependency.getModuleArtifacts();
 
                 final HashSet<String> types = new HashSet<>();
@@ -201,8 +202,15 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                     if (projects.size() > 1) {
                         throw new GradleException("Multiple projects are found in dependency: " + dependency.toString());
                     }
-                    dependencies.add(project.getDependencies().create(
-                                         project.project(projects.iterator().next().getProjectPath())));
+                    final ProjectComponentIdentifier projectIdentifier = projects.iterator().next();
+
+                    final HashMap<String, String> notation = new HashMap<>();
+                    notation.put("path", projectIdentifier.getProjectPath());
+                    // TODO: Find a better way to decide whether to add "configuration" or not.
+                    if (dependencyConfiguration != null && !dependencyConfiguration.isEmpty()) {
+                        notation.put("configuration", dependencyConfiguration);
+                    }
+                    dependencies.add(project.getDependencies().create(project.getDependencies().project(notation)));
                 } else if (types.contains("module")) {
                     final HashMap<String, String> notation = new HashMap<>();
                     notation.put("group", dependency.getModuleGroup());

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -202,6 +202,10 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                     if (projects.size() > 1) {
                         throw new GradleException("Multiple projects are found in dependency: " + dependency.toString());
                     }
+                    if (projects.isEmpty()) {
+                        throw new IllegalStateException(
+                                "Internal error which must not happen: projects is empty while tasks has \"project\".");
+                    }
                     final ProjectComponentIdentifier projectIdentifier = projects.iterator().next();
 
                     final HashMap<String, String> notation = new HashMap<>();


### PR DESCRIPTION
To emulate `compile project(":subproject")` properly, we needed to use `DependencyHandler#project`, not `Project#project`, for `DependencyHandler#create`.
* https://docs.gradle.org/6.2.2/javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html#project-java.util.Map-
* https://docs.gradle.org/6.2.2/javadoc/org/gradle/api/Project.html#project-java.lang.String-

(Otherwise, the passed `project` object may not have perfect information, and it may not always work well.)

----

With this change, we now can pass the `configuration` parameter to `project` like `compile project(path: "subproject", configuration: "shadow")` at the same time.
