### PR TITLE
Build gems even in Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
         os:
         - ubuntu-latest
         - macOS-latest
+        - windows-latest
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8
@@ -17,3 +18,8 @@ jobs:
         java-version: 1.8
     - name: Build and test
       run: ./gradlew --stacktrace check
+    - uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: ${{ matrix.os }}
+        path: build/reports

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation gradleApi()
 
     testImplementation gradleTestKit()
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.0"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.2"
 }
 
 test {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -397,7 +399,7 @@ class Gem extends AbstractArchiveTask {
         writer.println("    spec.authors       = [" + renderList(this.authors.get()) + "]");
         writer.println("    spec.files         = [");
         for (final Path file : files) {
-            writer.println("        \"" + file.toString() + "\",");
+            writer.println("        \"" + pathToStringWithSlashes(file) + "\",");
         }
         writer.println("    ]");
         writer.println("    spec.name          = \"" + this.getArchiveBaseName().get() + "\"");
@@ -451,6 +453,30 @@ class Gem extends AbstractArchiveTask {
         // rubygems_version
         // signing_key
         writer.println("end");
+    }
+
+    static String pathToStringWithSlashesForTesting(final Path path) {
+        return pathToStringWithSlashes(path);
+    }
+
+    /**
+     * Convert the specified path to String, always separated with {@code "/"} even in Windows.
+     */
+    private static String pathToStringWithSlashes(final Path path) {
+        if (File.separatorChar == '/') {
+            return path.toString();
+        }
+
+        final StringBuilder builder = new StringBuilder();
+
+        final Path root = path.getRoot();
+        if (root != null) {
+            builder.append(root.toString().replace(File.separatorChar, '/'));
+        }
+
+        final Stream<Path> pathElementStream = StreamSupport.stream(path.spliterator(), false);
+        builder.append(pathElementStream.map(pathElement -> pathElement.toString()).collect(Collectors.joining("/")));
+        return builder.toString();
     }
 
     private final Property<String> embulkPluginMainClass;

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
@@ -46,6 +46,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -53,8 +55,17 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+/**
+ * Tests the Embulk plugins Gradle plugin by {@code org.gradle.testkit.runner.GradleRunner}.
+ *
+ * <p>Those tests are tentatively disabled on Windows. {@code GradleRunner} may keep some related files open.
+ * It prevents JUnit 5 from removing the temporary directory ({@code TempDir}).
+ *
+ * @see <a href="https://github.com/embulk/gradle-embulk-plugins/runs/719452273">A failed test</a>
+ */
 class TestEmbulkPluginsPlugin {
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testPublish(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test1"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build.gradle"),
@@ -74,6 +85,7 @@ class TestEmbulkPluginsPlugin {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testEmbulkPluginRuntimeConfiguration(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test2"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build2.gradle"),
@@ -86,6 +98,7 @@ class TestEmbulkPluginsPlugin {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testVariableMainJar(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test3"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build3.gradle"),
@@ -122,6 +135,7 @@ class TestEmbulkPluginsPlugin {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testNoGenerateRubyCode(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test4"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build4.gradle"),
@@ -141,6 +155,7 @@ class TestEmbulkPluginsPlugin {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testRubyVersion(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-test5"));
         Files.copy(TestEmbulkPluginsPlugin.class.getClassLoader().getResourceAsStream("build5.gradle"),
@@ -152,6 +167,7 @@ class TestEmbulkPluginsPlugin {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testSubprojects(@TempDir Path tempDir) throws IOException {
         final Path projectDir = Files.createDirectory(tempDir.resolve("embulk-input-subprojects"));
         final Path sublibDir = Files.createDirectory(projectDir.resolve("sublib"));

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestGem.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestGem.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestGem {
+    @Test
+    public void testPathsWithSlashes(@TempDir Path tempDir) throws IOException {
+        Files.copy(TestGem.class.getClassLoader().getResourceAsStream("build.gradle"),
+                   tempDir.resolve("file0"));
+        final Path dir1 = Files.createDirectory(tempDir.resolve("sub1"));
+        Files.copy(TestGem.class.getClassLoader().getResourceAsStream("build.gradle"),
+                   dir1.resolve("file1"));
+        Files.copy(TestGem.class.getClassLoader().getResourceAsStream("build.gradle"),
+                   dir1.resolve("file2"));
+        final Path dir2 = Files.createDirectory(dir1.resolve("sub2"));
+        Files.copy(TestGem.class.getClassLoader().getResourceAsStream("build.gradle"),
+                   dir2.resolve("file3"));
+
+        final String[] foundPathsWithSlashes = listFiles(tempDir).stream()
+                .map(path -> Gem.pathToStringWithSlashesForTesting(path))
+                .sorted()
+                .toArray(String[]::new);
+
+        assertEquals(4, foundPathsWithSlashes.length);
+        assertEquals("file0", foundPathsWithSlashes[0]);
+        assertEquals("sub1/file1", foundPathsWithSlashes[1]);
+        assertEquals("sub1/file2", foundPathsWithSlashes[2]);
+        assertEquals("sub1/sub2/file3", foundPathsWithSlashes[3]);
+    }
+
+    private static List<Path> listFiles(final Path root) throws IOException {
+        final ArrayList<Path> files = new ArrayList<>();
+
+        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                files.add(root.relativize(file));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return Collections.unmodifiableList(files);
+    }
+}


### PR DESCRIPTION
Embulk plugin gems did not build successfully on Windows because generated gemspec files
included Windows-style file paths separated with backslashes (`"\"`), such as:

```
    spec.files         = [
        "classpath\embulk-input-db2-0.11.0.jar",
        "classpath\embulk-input-jdbc-0.11.0.jar",
        "lib\embulk\input\db2.rb",
        ...
```

In gemspecs, those paths should be in UNIX-style even if building on Windows.