### PR TITLE
Add "ignoreConflicts" property in the "embulkPlugin" task

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ In the beginning of your Embulk plugin project, or after migrating your Embulk p
           exclude group: "javax.inject", module: "javax.inject"  // embulk-core depends on javax.inject.
       }
       ```
+      * If a dependency needs to be duplicated intentionally, add `ignoreConflicts` in the `embulkPlugins` block. See below.
 4. Add required `testCompile` if depending on `embulk-core:0.9.22+`.
     * If depending on `embulk-core:0.9.22`:
       ```
@@ -255,6 +256,18 @@ In the beginning of your Embulk plugin project, or after migrating your Embulk p
         category = "input"
         type = "dummy"
     }
+    * If a dependency (or dependencies) needs to be duplicated intentionally, add `ignoreConflicts` here in the `embulkPlugin` task like below. It does not affect any deliverable although it shows to ignore the conflict(s) in the related warning message.
+      ```
+      embulkPlugin {
+          mainClass = "org.embulk.input.dummy.DummyInputPlugin"
+          category = "input"
+          type = "dummy"
+          ignoreConflicts = [
+              [ group: "javax.inject", module: "javax.inject" ],
+              ...
+          ]
+      }
+      ```
 11. Configure publishing the plugin JAR to the Maven repository where you want to upload.
     * The standard `jar` task is already reconfigured to generate a JAR ready as an Embulk plugin.
     * Note that `uploadArchives` with the `maven` plugin is no longer supported.

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginsPlugin.java
@@ -95,6 +95,9 @@ class TestEmbulkPluginsPlugin {
         final Path lockfilePath = projectDir.resolve("gradle/dependency-locks/embulkPluginRuntime.lockfile");
         assertTrue(Files.exists(lockfilePath));
         assertFileDoesNotContain(lockfilePath, "javax.inject:javax.inject");
+        assertFileDoesNotContain(lockfilePath, "org.apache.commons:commons-lang3");
+        assertFileDoesContain(lockfilePath, "org.apache.bval:bval-jsr303");
+        assertFileDoesContain(lockfilePath, "org.apache.bval:bval-core");
     }
 
     @Test

--- a/src/test/resources/build2.gradle
+++ b/src/test/resources/build2.gradle
@@ -27,12 +27,19 @@ dependencies {
     compile("org.glassfish.jersey.core:jersey-client:2.25.1") {
         exclude group: "javax.inject", module: "javax.inject"
     }
+    compile("org.apache.bval:bval-jsr303:0.5") {
+        exclude group: "org.apache.commons", module: "commons-lang3"
+    }
 }
 
 embulkPlugin {
     mainClass = "org.embulk.input.test1.Test1InputPlugin"
     category = "input"
     type = "test1"
+    ignoreConflicts = [
+        [ group: "org.apache.bval", module: "bval-core" ],
+        [ group: "commons-beanutils", module: "commons-beanutils-core" ],
+    ]
 }
 
 publishing {


### PR DESCRIPTION
This Gradle plugin warns against dependencies duplicated with `embulk-core` (in `compileOnly`).

But in some cases with upcoming Embulk versions, some plugins would need to have such duplicated dependencies intentionally. A typical cause is dependency removal from `embulk-core`.

For example, `embulk-core` would remove Jackson from its dependencies soon. To keep a plugin working before and after the removal (for a while), the plugin needs to have its own Jackson. It should be okay if the versions of Jackson libraries are 100% identical.

The `ignoreConflicts` property does not affect any deliverable. It just changes the warning message about dependency duplication like below.

```
============================================ WARNING ============================================
Following "runtime" dependencies are included also in "compileOnly" dependencies.

  "javax.validation:validation-api:1.1.0.Final"
  ([IGNORE IT] "javax.inject:javax.inject:1")
  ...
```
