### PR TITLE
Support JAR classifiers

### DIFF
--- a/src/test/resources/build.gradle
+++ b/src/test/resources/build.gradle
@@ -25,6 +25,8 @@ tasks.withType(JavaCompile) {
 dependencies {
     compileOnly "org.embulk:embulk-core:0.9.17"
     compile "org.apache.commons:commons-text:1.7"
+    compile "com.github.jnr:jffi:1.2.23"
+    compile "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {

--- a/src/test/resources/build2.gradle
+++ b/src/test/resources/build2.gradle
@@ -30,6 +30,8 @@ dependencies {
     compile("org.apache.bval:bval-jsr303:0.5") {
         exclude group: "org.apache.commons", module: "commons-lang3"
     }
+    compile "com.github.jnr:jffi:1.2.23"
+    compile "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {

--- a/src/test/resources/build4.gradle
+++ b/src/test/resources/build4.gradle
@@ -24,6 +24,8 @@ tasks.withType(JavaCompile) {
 dependencies {
     compileOnly "org.embulk:embulk-core:0.9.17"
     compile "javax.json:javax.json-api:1.1.4"
+    compile "com.github.jnr:jffi:1.2.23"
+    compile "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {


### PR DESCRIPTION
The Gradle plugin was not working well for an Embulk plugin that contains a dependency on an artifact with a "classifier". An example is: `com.github.jnr:jffi:1.2.23:native`.

https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.23/

This pull-req is to support such a case with a "classifier".