### PR TITLE
Disable generating Gradle's Module Metadata by default

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -52,6 +52,8 @@ public class EmbulkPluginExtension {
         this.category = objectFactory.property(String.class);
         this.type = objectFactory.property(String.class);
         this.mainJar = objectFactory.property(String.class);
+        this.generatesModuleMetadata = objectFactory.property(Boolean.class);
+        this.generatesModuleMetadata.set(false);
         this.ignoreConflicts = castedListProperty(objectFactory);
     }
 
@@ -69,6 +71,10 @@ public class EmbulkPluginExtension {
 
     public Property<String> getMainJar() {
         return this.mainJar;
+    }
+
+    public Property<Boolean> getGeneratesModuleMetadata() {
+        return this.generatesModuleMetadata;
     }
 
     public ListProperty<Map<String, String>> getIgnoreConflicts() {
@@ -149,5 +155,6 @@ public class EmbulkPluginExtension {
     private final Property<String> category;
     private final Property<String> type;
     private final Property<String> mainJar;
+    private final Property<Boolean> generatesModuleMetadata;
     private final ListProperty<Map<String, String>> ignoreConflicts;
 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -45,6 +45,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 
@@ -92,6 +93,12 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
         final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
 
         extension.checkValidity();
+
+        if (!extension.getGeneratesModuleMetadata().getOrElse(false)) {
+            project.getTasks().withType(GenerateModuleMetadata.class, configureAction -> {
+                configureAction.setEnabled(false);
+            });
+        }
 
         // TODO: Reconsider a possibility that it can be a detached configuration.
         // It must have been a non-detached configuration to be mapped into Maven scopes by Conf2ScopeMapping,


### PR DESCRIPTION
An Embulk plugin trusts its `pom.xml` for declaring its dependencies. It's because the Embulk core uses plugin's `pom.xml` for loading a Maven-based plugin.

On the other hand, Gradle has had its own "Module Metadata" to declare dependencies. "Module Metadata" is uploaded into Maven Central in addition to `pom.xml`. As a consumer, Gradle uses the Module Metadata if found, instead of `pom.xml`.

https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html

A Maven-based Embulk plugin has some hacks in `pom.xml`, then, `pom.xml` and Gradle's Module Metadata can sometimes cotradict. Co-existing two declarations cause confusions.

This PR is to disable Gradle's Module Metadata by default to avoid the confusion.