### PR TITLE
Rebuild pom.xml from compileClasspath and runtimeClasspath

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/DependenciesNodeManipulator.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/DependenciesNodeManipulator.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import groovy.util.Node;
+import groovy.util.NodeList;
+import groovy.xml.QName;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+
+/**
+ * A wrapping manipulator of {@code <dependencies>} node.
+ *
+ * <p>A typical use of this class is:
+ *
+ * <pre>{@code // DependenciesNodeManipulator implements Autocloseable.
+ * try (final DependenciesNodeManipulator xml = DependenciesNodeManipulator.of(node)) {
+ *     xml.insertProvidedDependency(...);  // Reserved to commit at last.
+ *     xml.applyCompileRuntimeDependency(...);  // Reserved to commit at last.
+ *     // ...
+ *     xml.toCommit();  // Determied to commit.
+ * }  // Manipulations are actually committed in XML at last in close().
+ * }</pre>
+ */
+final class DependenciesNodeManipulator implements AutoCloseable {
+    private DependenciesNodeManipulator(
+            final Node pom,
+            final Node dependencies,
+            final NodeList dependenciesChildren,
+            final LinkedHashMap<VersionlessDependency, Node> nodeMap,
+            final Logger logger) {
+        this.pom = pom;
+        this.dependencies = dependencies;
+        this.dependenciesChildren = dependenciesChildren;
+        this.nodeMap = Collections.unmodifiableMap(nodeMap);
+        this.dependencyManagementsToRemove = new ArrayList<>();
+        this.providedDependenciesToInsert = new LinkedHashMap<>();
+        this.existingDependenciesToModify = new LinkedHashMap<>();
+        this.compileRuntimeDependenciesToAppend = new LinkedHashMap<>();
+        this.toCommit = false;
+        this.prefixForLoggingAfterCommit = null;
+        this.logger = logger;
+    }
+
+    static DependenciesNodeManipulator of(
+            final Node pom,
+            final Logger logger) {
+        final Node dependencies = getSingleInnerNode(pom, "dependencies", "pom");
+
+        final NodeList children;
+        try {
+            children = (NodeList) dependencies.children();
+        } catch (final ClassCastException ex) {
+            throw new GradleException("<dependencies> includes an invalid child node unexpectedly.", ex);
+        }
+
+        final LinkedHashMap<VersionlessDependency, Node> nodeMap = new LinkedHashMap<>();
+
+        for (final Object dependencyObject : children) {
+            final Node dependencyNode;
+            try {
+                dependencyNode = (Node) dependencyObject;
+                if (dependencyNode.name() instanceof QName) {
+                    final QName dependencyName = (QName) dependencyNode.name();
+                    if (!"dependency".equals(dependencyName.getQualifiedName())) {
+                        throw new GradleException("<dependencies> includes a non-<dependency> child node unexpectedly.");
+                    }
+                } else if (dependencyNode.name() instanceof String) {
+                    final String dependencyName = (String) dependencyNode.name();
+                    if (!"dependency".equals(dependencyName)) {
+                        throw new GradleException("<dependencies> includes a non-<dependency> child node unexpectedly.");
+                    }
+                }
+            } catch (final ClassCastException ex) {
+                throw new GradleException("<dependencies> includes an invalid child node unexpectedly.", ex);
+            }
+
+            final VersionlessDependency dependency = VersionlessDependency.of(
+                    getGroupId(dependencyNode, null),
+                    getArtifactId(dependencyNode, null),
+                    getClassifier(dependencyNode, null));
+            nodeMap.put(dependency, dependencyNode);
+        }
+
+        return new DependenciesNodeManipulator(pom, dependencies, children, nodeMap, logger);
+    }
+
+    void assertScopes() {
+        for (final Object dependencyObject : this.dependenciesChildren) {
+            final Node dependencyNode;
+            try {
+                dependencyNode = (Node) dependencyObject;
+                final QName dependencyName = (QName) dependencyNode.name();
+                if (!"dependency".equals(dependencyName.getQualifiedName())) {
+                    throw new GradleException("<dependencies> includes a non-<dependency> child node unexpectedly.");
+                }
+            } catch (final ClassCastException ex) {
+                throw new GradleException("<dependencies> includes an invalid child node unexpectedly.", ex);
+            }
+            final MavenScope scope = getScope(dependencyNode);
+            if (scope == MavenScope.PROVIDED) {
+                throw new GradleException("<dependencies> includes a dependency with a provided scope unexpectedly.");
+            }
+            if (scope == MavenScope.SYSTEM) {
+                throw new GradleException("<dependencies> includes a dependency with a system scope unexpectedly.");
+            }
+        }
+    }
+
+    /**
+     * Remove the {@code <dependencyManagement>} BOM node.
+     */
+    void removeDependencyManagement() {
+        final Node dependencyManagement = getSingleInnerNode(pom, "dependencyManagement", "pom");
+        if (dependencyManagement != null) {
+            this.dependencyManagementsToRemove.add(dependencyManagement);
+        }
+    }
+
+    /**
+     * Insert a new {@code <dependency>} node at the top, or update an existing {@code <dependency>}.
+     */
+    Node insertProvidedDependency(final ScopedDependency dependency) {
+        final Node node = newDependencyNode(dependency);
+        this.providedDependenciesToInsert.put(dependency, node);
+        return node;
+    }
+
+    /**
+     * Append a new {@code <dependency>} node at the bottom, or update an existing {@code <dependency>}.
+     */
+    Node applyCompileRuntimeDependency(final ScopedDependency dependency) {
+        final Node found = this.nodeMap.get(dependency.getVersionlessDependency());
+        if (found != null) {
+            this.existingDependenciesToModify.put(dependency, found);
+            return found;
+        } else {
+            final Node node = newDependencyNode(dependency);
+            this.compileRuntimeDependenciesToAppend.put(dependency, node);
+            return node;
+        }
+    }
+
+    void logDependencies(final String prefix) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("\n");
+        for (final Object dependencyObject : this.dependenciesChildren) {
+            final Node dependencyNode;
+            try {
+                dependencyNode = (Node) dependencyObject;
+                if (dependencyNode.name() instanceof QName) {
+                    final QName dependencyName = (QName) dependencyNode.name();
+                    if (!"dependency".equals(dependencyName.getQualifiedName())) {
+                        throw new GradleException("<dependencies> includes a non-<dependency> child node unexpectedly.");
+                    }
+                } else if (dependencyNode.name() instanceof String) {
+                    final String dependencyName = (String) dependencyNode.name();
+                    if (!"dependency".equals(dependencyName)) {
+                        throw new GradleException("<dependencies> includes a non-<dependency> child node unexpectedly.");
+                    }
+                }
+            } catch (final ClassCastException ex) {
+                throw new GradleException("<dependencies> includes an invalid child node unexpectedly.", ex);
+            }
+
+            final VersionlessDependency dependency = VersionlessDependency.of(
+                    getGroupId(dependencyNode, null),
+                    getArtifactId(dependencyNode, null),
+                    getClassifier(dependencyNode, null));
+            builder.append("    => ");
+            builder.append(dependency.toString(
+                    getVersion(dependencyNode, "(empty)"),
+                    getScope(dependencyNode)));
+            builder.append("\n");
+        }
+
+        this.logger.lifecycle(prefix + "{}", builder.toString());
+    }
+
+    void toCommit(final String prefixForLogging) {
+        this.toCommit = true;
+        this.prefixForLoggingAfterCommit = prefixForLogging;
+    }
+
+    @Override
+    public void close() {
+        if (this.toCommit) {  // Commit reserved operations to the actual XML.
+            for (final Node dependencyManagement : this.dependencyManagementsToRemove) {
+                this.logger.lifecycle("<dependencyManagement> is going to be removed.");
+                this.pom.remove(dependencyManagement);
+            }
+
+            this.logger.lifecycle("<dependencies> is going to be updated:");
+
+            this.insertProvidedDependencies();
+
+            for (final Map.Entry<ScopedDependency, Node> entry : existingDependenciesToModify.entrySet()) {
+                this.logger.lifecycle("    => [MODIFY] {}", entry.getKey());
+                this.modifyExistingNode(entry.getValue(), entry.getKey());
+            }
+
+            this.appendCompileRuntimeDependencies();
+            this.logger.lifecycle("");
+
+            if (this.prefixForLoggingAfterCommit != null) {
+                this.logDependencies(this.prefixForLoggingAfterCommit);
+            }
+        } else {
+            this.logger.warn("<dependencies> won't change. Breaking out without committing.");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void insertProvidedDependencies() {
+        for (final Map.Entry<ScopedDependency, Node> entry : this.providedDependenciesToInsert.entrySet()) {
+            this.logger.lifecycle("    => [INSERT] {}", entry.getKey());
+        }
+        this.dependenciesChildren.addAll(0, this.providedDependenciesToInsert.values());
+    }
+
+    private Node modifyExistingNode(final Node node, final ScopedDependency dependency) {
+        boolean modified = false;
+        modified |= this.modifyVersionIfDifferent(node, dependency.getVersion());
+        modified |= this.modifyScopeIfDifferent(node, dependency.getScope());
+        modified |= this.overrideExclusions(node);
+        if (!modified) {
+            this.logger.lifecycle("      => no changes");
+        }
+        return node;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendCompileRuntimeDependencies() {
+        for (final Map.Entry<ScopedDependency, Node> entry : this.compileRuntimeDependenciesToAppend.entrySet()) {
+            this.logger.lifecycle("    => [APPEND] {}", entry.getKey());
+            this.dependenciesChildren.add(entry.getValue());
+        }
+    }
+
+    private boolean modifyVersionIfDifferent(final Node node, final String version) {
+        return modifyTextInSingleInnerNodeIfDifferent(node, "version", "dependency", version, this.logger);
+    }
+
+    private boolean modifyScopeIfDifferent(final Node node, final MavenScope scope) {
+        return modifyTextInSingleInnerNodeIfDifferent(node, "scope", "dependency", scope.toMavenString(), this.logger);
+    }
+
+    private boolean overrideExclusions(final Node node) {
+        final Node exclusionsNode = getSingleInnerNode(node, "exclusions", "dependency");
+        if (exclusionsNode == null) {
+            this.logger.lifecycle("      => Add <exclusions><exclusion><groupId>*</groupId></exclusion></exclusions>");
+            final Node newExclusionsNode = node.appendNode("exclusions");
+            newExclusionsNode.append(newExclusionNode());
+            return true;
+        }
+
+        return cleanupExclusions(exclusionsNode, this.logger);
+    }
+
+    private static String getGroupId(final Node dependencyNode, final String defaultValue) {
+        return getTextInSingleInnerNode(dependencyNode, "groupId", "dependency", defaultValue);
+    }
+
+    private static String getArtifactId(final Node dependencyNode, final String defaultValue) {
+        return getTextInSingleInnerNode(dependencyNode, "artifactId", "dependency", defaultValue);
+    }
+
+    private static String getClassifier(final Node dependencyNode, final String defaultValue) {
+        return getTextInSingleInnerNode(dependencyNode, "classifier", "dependency", defaultValue);
+    }
+
+    private static String getVersion(final Node dependencyNode, final String defaultValue) {
+        return getTextInSingleInnerNode(dependencyNode, "version", "dependency", defaultValue);
+    }
+
+    private static MavenScope getScope(final Node dependencyNode) {
+        final String scope = getTextInSingleInnerNode(dependencyNode, "scope", "dependency", null);
+        if (scope == null) {
+            throw new GradleException("A <dependency> node has no <scope>.");
+        }
+        return MavenScope.of(scope);
+    }
+
+    private static boolean modifyTextInSingleInnerNodeIfDifferent(
+            final Node node,
+            final String key,
+            final String parentName,
+            final String prospectiveText,
+            final Logger logger) {
+        final Node innerNode = getSingleInnerNode(node, key, parentName);
+        if (innerNode == null) {
+            logger.lifecycle("      => Add <{}>: {}", key, prospectiveText);
+            node.append(newTextNode(key, prospectiveText));
+            return true;
+        }
+
+        final Object innerValueObject = innerNode.value();
+        try {
+            final String existingText;
+            if (innerValueObject instanceof NodeList) {
+                final NodeList innerValues = (NodeList) innerValueObject;
+                if (innerValues.isEmpty()) {
+                    logger.lifecycle("      => Add <{}>: {}", key, prospectiveText);
+                    node.append(newTextNode(key, prospectiveText));
+                    return true;
+                }
+                if (innerValues.size() > 1) {
+                    throw new GradleException("<" + key + "> in <" + parentName + "> includes multiple values unexpectedly.");
+                }
+                existingText = (String) innerValues.get(0);
+            } else if (innerValueObject instanceof CharSequence) {
+                existingText = innerValueObject.toString();
+            } else {
+                existingText = (String) innerValueObject;  // throws ClassCastException
+            }
+
+            if (!prospectiveText.equals(existingText)) {
+                logger.lifecycle("      => Update <{}>: {} => {}", key, existingText, prospectiveText);
+                innerNode.setValue(prospectiveText);
+                return true;
+            }
+            return false;
+        } catch (final ClassCastException ex) {
+            throw new GradleException("<" + key + "> in <" + parentName + "> includes an invalid child node unexpectedly.", ex);
+        }
+    }
+
+    /**
+     * Make {@code <exclusions>} node consist of only {@code <exclusion><groupId>*</groupId></exclusion>}.
+     */
+    private static boolean cleanupExclusions(final Node node, final Logger logger) {
+        boolean modified = false;
+
+        final Object exclusionNodesObject1 = node.get("exclusion");
+        if (exclusionNodesObject1 instanceof NodeList) {
+            final NodeList exclusionNodes = (NodeList) exclusionNodesObject1;
+            if (exclusionNodes.size() >= 1) {
+                // NOTE: NodeList's iterator does not support Iterator#remove, unfortunately. :(
+                // https://issues.apache.org/jira/browse/GROOVY-1832
+                // https://stackoverflow.com/questions/1374088/removing-dom-nodes-when-traversing-a-nodelist
+                //
+                // So much traditional way...
+                for (int i = exclusionNodes.size() - 1; i >= 0; i--) {
+                    final Node exclusionNode;
+                    try {
+                        exclusionNode = (Node) exclusionNodes.get(i);
+                    } catch (final ClassCastException ex) {
+                        throw new GradleException("<exclusion> in <exclusions> is not a Node.", ex);
+                    }
+                    if (!isExclusionForAny(exclusionNode)) {
+                        modified = true;
+                        logger.lifecycle("      => Remove {}", exclusionToString(exclusionNode));
+                        node.remove(exclusionNode);
+                    }
+                }
+            }
+
+            // Even after some elements are removed from |exclusionNodes|,
+            // the |exclusionNodes| object behaves like its element(s) were not removed
+            // for example in |NodeList#isEmpty()|, |NodeList#size()|, and else.
+            //
+            // To work around this issue in Groovy's NodeList,
+            // regetting <exclusion> nodes from <exclusions> **again** below.
+        }
+
+        final Object exclusionNodesObject2 = node.get("exclusion");
+        if (exclusionNodesObject2 instanceof NodeList) {
+            final NodeList exclusionNodes = (NodeList) exclusionNodesObject2;
+            if (exclusionNodes.isEmpty()) {
+                modified = true;
+                logger.lifecycle("      => Add <exclusion><groupId>*</groupId></exclusion>");
+                node.append(newExclusionNode());
+            }
+        }
+
+        return modified;
+    }
+
+    private static boolean isExclusionForAny(final Node node) {
+        final String groupId = getTextInSingleInnerNode(node, "groupId", "exclusion", null);
+        if (!"*".equals(groupId)) {  // null is unaccepted.
+            return false;
+        }
+
+        final String artifactId = getTextInSingleInnerNode(node, "artifactId", "exclusion", null);
+        if (artifactId == null || "*".equals(artifactId)) {  // null is accepted.
+            return true;
+        }
+
+        return false;
+    }
+
+    private static String exclusionToString(final Node node) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("<exclusion>");
+
+        final String groupId = getTextInSingleInnerNode(node, "groupId", "exclusion", null);
+        if (groupId != null) {
+            builder.append("<groupId>");
+            builder.append(groupId);
+            builder.append("</groupId>");
+        }
+
+        final String artifactId = getTextInSingleInnerNode(node, "artifactId", "exclusion", null);
+        if (artifactId != null) {
+            builder.append("<artifactId>");
+            builder.append(artifactId);
+            builder.append("</artifactId>");
+        }
+
+        builder.append("</exclusion>");
+        return builder.toString();
+    }
+
+    private static String getTextInSingleInnerNode(
+            final Node node,
+            final String key,
+            final String parentName,
+            final String defaultText) {
+        final Node innerNode = getSingleInnerNode(node, key, parentName);
+        if (innerNode == null) {
+            return defaultText;
+        }
+
+        final Object innerValueObject = innerNode.value();
+        try {
+            if (innerValueObject instanceof NodeList) {
+                final NodeList innerValues = (NodeList) innerValueObject;
+                if (innerValues.isEmpty()) {
+                    return defaultText;
+                }
+                if (innerValues.size() > 1) {
+                    throw new GradleException("<" + key + "> in <" + parentName + "> includes multiple values unexpectedly.");
+                }
+                return (String) innerValues.get(0);
+            } else if (innerValueObject instanceof String) {
+                return (String) innerValueObject;
+            }
+            throw new GradleException("<" + key + "> in <" + parentName + "> includes an unexpected child node.");
+        } catch (final ClassCastException ex) {
+            throw new GradleException("<" + key + "> in <" + parentName + "> includes an invalid child node unexpectedly.", ex);
+        }
+    }
+
+    private static Node getSingleInnerNode(final Node node, final String key, final String parentName) {
+        final Object innerNodeObject = node.get(key);
+
+        if (innerNodeObject instanceof NodeList) {
+            final NodeList innerNodes = (NodeList) innerNodeObject;
+            if (innerNodes.isEmpty()) {
+                return null;
+            }
+            if (innerNodes.size() > 1) {
+                throw new GradleException("<" + parentName + "> includes multiple <" + key + "> elements unexpectedly.");
+            }
+            return (Node) innerNodes.get(0);
+        }
+
+        try {
+            return (Node) innerNodeObject;
+        } catch (final ClassCastException ex) {
+            throw new GradleException("<" + key + "> in <" + parentName + "> includes neither NodeList nor Node unexpectedly.", ex);
+        }
+    }
+
+    private static Node newDependencyNode(final ScopedDependency dependency) {
+        final VersionlessDependency versionless = dependency.getVersionlessDependency();
+        final Node node = new Node(null, "dependency");
+        node.appendNode("groupId", versionless.getGroup());
+        node.appendNode("artifactId", versionless.getArtifactName());
+        if (versionless.getClassifier() != null) {
+            node.appendNode("classifier", versionless.getClassifier());
+        }
+        node.appendNode("version", dependency.getVersion());
+        node.appendNode("scope", dependency.getScope().toMavenString());
+
+        final Node exclusionsNode = node.appendNode("exclusions");
+        exclusionsNode.append(newExclusionNode());
+
+        return node;
+    }
+
+    private static Node newExclusionNode() {
+        final Node exclusionNode = new Node(null, "exclusion");
+        exclusionNode.appendNode("groupId", "*");
+        return exclusionNode;
+    }
+
+    private static Node newTextNode(final String key, final String value) {
+        return new Node(null, key, value);
+    }
+
+    // The primary target XML node.
+    private final Node pom;
+    private final Node dependencies;
+
+    // Cached nodes, and cached representations of dependencies.
+    private final NodeList dependenciesChildren;
+    private final Map<VersionlessDependency, Node> nodeMap;  // map to find Nodes from ProspectiveDependencies
+
+    // Operations reserved to be committed into the target XML node.
+    private final ArrayList<Node> dependencyManagementsToRemove;
+    private final LinkedHashMap<ScopedDependency, Node> providedDependenciesToInsert;  // key: logging, value: node to add
+    private final LinkedHashMap<ScopedDependency, Node> existingDependenciesToModify;  // key: prospect, value: node to modify
+    private final LinkedHashMap<ScopedDependency, Node> compileRuntimeDependenciesToAppend;  // key: logging, value: node to add
+
+    private boolean toCommit;
+    private String prefixForLoggingAfterCommit;
+
+    private final Logger logger;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -54,6 +54,8 @@ public class EmbulkPluginExtension {
         this.mainJar = objectFactory.property(String.class);
         this.generatesModuleMetadata = objectFactory.property(Boolean.class);
         this.generatesModuleMetadata.set(false);
+        this.directPomManipulation = objectFactory.property(Boolean.class);
+        this.directPomManipulation.set(false);
         this.ignoreConflicts = castedListProperty(objectFactory);
     }
 
@@ -75,6 +77,10 @@ public class EmbulkPluginExtension {
 
     public Property<Boolean> getGeneratesModuleMetadata() {
         return this.generatesModuleMetadata;
+    }
+
+    public Property<Boolean> getDirectPomManipulation() {
+        return this.directPomManipulation;
     }
 
     public ListProperty<Map<String, String>> getIgnoreConflicts() {
@@ -156,5 +162,6 @@ public class EmbulkPluginExtension {
     private final Property<String> type;
     private final Property<String> mainJar;
     private final Property<Boolean> generatesModuleMetadata;
+    private final Property<Boolean> directPomManipulation;
     private final ListProperty<Map<String, String>> ignoreConflicts;
 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -45,32 +45,64 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
- * A plugin for building Embulk plugins.
+ * A Gradle plugin for building Embulk plugins.
  *
- * <p>This implementation draws on Gradle's java-gradle-plugin plugin.
+ * <p>This Gradle plugin has two main purposes to satisfy two requirements as an Embulk plugin.
  *
- * @see <a href="https://github.com/gradle/gradle/blob/v5.5.1/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java">JavaGradlePluginPlugin</a>
+ * <p>One of the requirements is to get Embulk plugin's {@code pom.xml} to include all dependencies
+ * as the direct first-level dependencies without any transitive dependency. This is an important
+ * restriction to keep dependencies consistent between plugin development and Embulk's runtime.
+ * (Indeed, Embulk's {@code PluginClassLoader} is implemented for Maven-based plugins to load only
+ * the direct first-level dependencies without any transitive dependency.)
+ *
+ * <p>The other requirement is to add some required attributes in {@code MANIFEST.MF}.
+ *
+ * <p>In addition, this Gradle plugin provides some support for publishing RubyGems-based plugins.
+ *
+ * <p>This Gradle plugin depends on Gradle's "java-plugin" and "maven-publish-plugin".
  */
 public class EmbulkPluginsPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
-        // The "java" plugin is required to be applied so that the "runtime" configuration will be available.
+        // The "java" plugin is applied automatically here because :
+        // * An Embulk plugin is naturally expected to be a Java project.
+        // * This Gradle plugin needs "compileClasspath" and "runtimeClasspath" configurations available.
         project.getPluginManager().apply(JavaPlugin.class);
+
+        // The "maven-publish" plugin is applied automatically here because :
+        // * An Embulk plugin needs its POM (pom.xml) to be manipulated.
+        // * This Gradle plugin needs to interfere "publishing" to manipulate POM.
+        //
+        // It can be disabled in the future when the POM manipulation is realized by tweaking Gradle's "dependencies",
+        // not just at the "publishing".
+        project.getPluginManager().apply(MavenPublishPlugin.class);
 
         createExtension(project);
 
         project.getTasks().create("gem", Gem.class);
         project.getTasks().create("gemPush", GemPush.class);
 
-        final Configuration runtimeConfiguration = project.getConfigurations().getByName("runtime");
+        final Configuration compileClasspath = project.getConfigurations().getByName("compileClasspath");
+        final Configuration runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
 
         project.afterEvaluate(projectAfterEvaluate -> {
-            initializeAfterEvaluate(projectAfterEvaluate, runtimeConfiguration);
+            final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
+            extension.checkValidity();
+
+            if (extension.getDirectPomManipulation().getOrElse(false)) {
+                initializeForPomModifications(projectAfterEvaluate, extension, compileClasspath, runtimeClasspath);
+            } else {
+                final Configuration runtimeConfiguration = project.getConfigurations().getByName("runtime");
+                initializeForAlternativeRuntimeConfiguration(projectAfterEvaluate, extension, runtimeConfiguration);
+            }
         });
     }
 
@@ -87,13 +119,127 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                 project);
     }
 
-    private static void initializeAfterEvaluate(
+    private static void initializeForPomModifications(
             final Project project,
+            final EmbulkPluginExtension extension,
+            final Configuration compileClasspath,
+            final Configuration runtimeClasspath) {
+        if (extension.getMainJar().isPresent()) {
+            throw new GradleException(
+                    "mainJar is not supported with direct pom.xml manipulation."
+                    + " Contact at https://github.com/embulk/gradle-embulk-plugins/issues for your case.");
+        }
+
+        if (!extension.getGeneratesModuleMetadata().getOrElse(false)) {
+            project.getTasks().withType(GenerateModuleMetadata.class, configureGenerateModuleMetadata -> {
+                configureGenerateModuleMetadata.setEnabled(false);
+            });
+        }
+
+        // The "compileClasspath" and "runtimeClasspath" configurations have dependency locking activated by default.
+        // https://docs.gradle.org/current/userguide/dependency_locking.html
+        compileClasspath.getResolutionStrategy().activateDependencyLocking();
+        runtimeClasspath.getResolutionStrategy().activateDependencyLocking();
+
+        configureJarTask(project, extension);
+
+        final PublishingExtension publishing = getPublishingExtension(project);
+
+        publishing.getPublications().withType(MavenPublication.class, configureMavenPublication -> {
+            // Embulk plugin's pom.xml should be on "Resolved versions", not "Declared versions".
+            // https://docs.gradle.org/6.4.1/userguide/publishing_maven.html#publishing_maven:resolved_dependencies
+            //
+            // It is to satisfy Embulk plugin's requirement for pom.xml to include all dependencies
+            // as the direct first-level dependencies without any transitive dependency.
+            configureMavenPublication.versionMapping(configureVersionMappingStrategy -> {
+                configureVersionMappingStrategy.usage("java-api", configureVariantVersionMappingStrategy -> {
+                    configureVariantVersionMappingStrategy.fromResolutionOf(runtimeClasspath);
+                });
+                configureVersionMappingStrategy.usage("java-runtime", configureVariantVersionMappingStrategy -> {
+                    configureVariantVersionMappingStrategy.fromResolutionResult();
+                });
+            });
+
+            if (project.getRepositories().isEmpty()) {
+                throw new GradleException(
+                        "No \"repositories {}\" are declared. Set at least one repository."
+                        + " For example: \"repositories { mavenCentral() }\"");
+            }
+
+            // NOTE: This "Action<? super XmlProvider> action" runs only when corresponding pom.xml is generated.
+            //
+            // In other words, this action does not run only when "./gradlew compileJava".
+            // It runs only when "./gradlew generatePomFileFor..." or "./gradlew publish..." runs.
+            //
+            // @see https://docs.gradle.org/6.4.1/javadoc/org/gradle/api/publish/maven/MavenPom.html#withXml-org.gradle.api.Action-
+            //
+            // """
+            // Each action/closure passed to this method will be stored as a callback, and executed
+            // when the publication that this descriptor is attached to is published.
+            // """
+            configureMavenPublication.getPom().withXml(configureXml -> {
+                final Logger logger = project.getLogger();
+
+                final ProspectiveDependencies prospectiveDependencies = ProspectiveDependencies.build(
+                        compileClasspath.getResolvedConfiguration().getResolvedArtifacts(),
+                        runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts(),
+                        logger);
+
+                // TODO: Use XmlProvider#asElement (org.w3c.dom.Element) instead of XmlProvider#asNode (groovy.util.Node).
+                // https://docs.gradle.org/6.4.1/javadoc/org/gradle/api/XmlProvider.html
+                //
+                // groovy.util.Node is Groovy's. Gradle is migrating to Kotlin, instead of Groovy.
+                // There is a risk that XmlProvider#asNode (groovy.util.Node) is deprecated / removed in the future.
+                //
+                // But, XmlProvider does not have a good way to create a new org.w3c.dom.Element without org.w3c.dom.Document.
+                try (final DependenciesNodeManipulator xml = DependenciesNodeManipulator.of(configureXml.asNode(), logger)) {
+                    xml.logDependencies("<dependencies> in pom.xml before manipulation:");
+                    xml.assertScopes();
+
+                    logger.lifecycle(
+                            "<dependencies> should be as follows, from compileClasspath and runtimeClasspath:{}",
+                            prospectiveDependencies.toStringForLogging());
+
+                    xml.removeDependencyManagement();
+
+                    for (final ScopedDependency dependency : prospectiveDependencies) {
+                        switch (dependency.getScope()) {
+                            case PROVIDED:
+                                xml.insertProvidedDependency(dependency);
+                                break;
+                            case COMPILE:
+                            case RUNTIME:
+                                xml.applyCompileRuntimeDependency(dependency);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    xml.toCommit("<dependencies> in pom.xml after manipulation:");
+                }
+            });
+        });
+
+        configureGemTasks(project, extension, runtimeClasspath);
+    }
+
+    private static PublishingExtension getPublishingExtension(final Project project) {
+        final Object publishingExtensionObject = project.getExtensions().findByName("publishing");
+        if (publishingExtensionObject == null) {
+            throw new GradleException("The plugin \"maven-publish\" is not applied.");
+        }
+        try {
+            return (PublishingExtension) publishingExtensionObject;
+        } catch (final ClassCastException ex) {
+            throw new GradleException("Failed unexpectedly to cast \"project.publishing\" to \"PublishingExtension\".", ex);
+        }
+    }
+
+    private static void initializeForAlternativeRuntimeConfiguration(
+            final Project project,
+            final EmbulkPluginExtension extension,
             final Configuration runtimeConfiguration) {
-        final EmbulkPluginExtension extension = project.getExtensions().getByType(EmbulkPluginExtension.class);
-
-        extension.checkValidity();
-
         if (!extension.getGeneratesModuleMetadata().getOrElse(false)) {
             project.getTasks().withType(GenerateModuleMetadata.class, configureAction -> {
                 configureAction.setEnabled(false);
@@ -376,7 +522,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
     private static void configureGemTasks(
             final Project project,
             final EmbulkPluginExtension extension,
-            final Configuration alternativeRuntimeConfiguration) {
+            final Configuration runtimeClasspath) {
         final TaskProvider<Gem> gemTask = project.getTasks().named("gem", Gem.class, task -> {
             final String mainJarTaskName;
             if (extension.getMainJar().isPresent()) {
@@ -406,7 +552,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             }
 
             task.getDestinationDirectory().set(((File) project.property("buildDir")).toPath().resolve("gems").toFile());
-            task.from(alternativeRuntimeConfiguration, copySpec -> {
+            task.from(runtimeClasspath, copySpec -> {
                 copySpec.into("classpath");
             });
             task.from(((Jar) project.getTasks().getByName(mainJarTaskName)).getArchiveFile(), copySpec -> {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/MavenScope.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/MavenScope.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.util.Locale;
+
+enum MavenScope {
+    // https://maven.apache.org/pom.html
+    COMPILE,
+    PROVIDED,
+    RUNTIME,
+    TEST,
+    SYSTEM,
+    ;
+
+    static MavenScope of(final String scope) {
+        return valueOf(scope.toUpperCase(Locale.ROOT));
+    }
+
+    String toMavenString() {
+        return this.toString().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/ProspectiveDependencies.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/ProspectiveDependencies.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions anda
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.logging.Logger;
+
+/**
+ * A prospective set of dependencies that {@code pom.xml} should finally morph into.
+ */
+final class ProspectiveDependencies implements Iterable<ScopedDependency> {
+    private ProspectiveDependencies(final LinkedHashMap<VersionlessDependency, VersionScope> dependencies) {
+        this.dependencies = Collections.unmodifiableMap(dependencies);
+
+        final ArrayList<ScopedDependency> scopedDependencies = new ArrayList<>();
+        for (final Map.Entry<VersionlessDependency, VersionScope> entry : dependencies.entrySet()) {
+            scopedDependencies.add(ScopedDependency.of(entry.getKey(), entry.getValue().getVersion(), entry.getValue().getScope()));
+        }
+        this.scopedDependencies = Collections.unmodifiableList(scopedDependencies);
+    }
+
+    /**
+     * Builds a set of dependencies from {@code compileClasspath} and {@code runtimeClasspath}.
+     *
+     * <p>If a dependency is :
+     *
+     * <ul>
+     * <li>Included both in {@code compileClasspath} and {@code runtimeClasspath}: {@code compile} scope in Maven
+     * <li>Included only in {@code runtimeClasspath}, not in {@code compileClasspath}: {@code runtime} scope in Maven
+     * <li>Included only in {@code compileClasspath}, not in {@code runtimeClasspath}: {@code provided} scope in Maven (compileOnly)
+     * </ul>
+     */
+    static ProspectiveDependencies build(
+            final Set<ResolvedArtifact> compileClasspath,
+            final Set<ResolvedArtifact> runtimeClasspath,
+            final Logger logger) {
+        logger.lifecycle("compileClasspath:");
+        for (final ResolvedArtifact compileArtifact : compileClasspath) {
+            logger.lifecycle(
+                    "    => {}:{}{}:{}",
+                    compileArtifact.getModuleVersion().getId().getGroup(),
+                    compileArtifact.getModuleVersion().getId().getName(),
+                    compileArtifact.getClassifier() == null ? "" : (":" + compileArtifact.getClassifier()),
+                    compileArtifact.getModuleVersion().getId().getVersion());
+        }
+        logger.lifecycle("");
+        logger.lifecycle("runtimeClasspath:");
+        for (final ResolvedArtifact runtimeArtifact : runtimeClasspath) {
+            logger.lifecycle(
+                    "    => {}:{}{}:{}",
+                    runtimeArtifact.getModuleVersion().getId().getGroup(),
+                    runtimeArtifact.getModuleVersion().getId().getName(),
+                    runtimeArtifact.getClassifier() == null ? "" : (":" + runtimeArtifact.getClassifier()),
+                    runtimeArtifact.getModuleVersion().getId().getVersion());
+        }
+        logger.lifecycle("");
+        return new Builder().addCompileClasspath(compileClasspath).addRuntimeClasspath(runtimeClasspath).build();
+    }
+
+    /**
+     * Builds a set of dependencies from version maps.
+     *
+     * <p>A version map mean {@code Map<VersionlessDependency, String>}, whose key is a tuple of
+     * group, module (artifact name), and classifier, and whose value is a version.
+     *
+     * <pre>{@code {
+     *   {"org.embulk", "embulk-spi", null} : "0.10.35",
+     *   {"org.msgpack", "msgpack-core", null} : "0.8.24",
+     *   {"com.github.jnr", "jffi", null} : "1.2.23",
+     *   {"com.github.jnr", "jffi", "native"} : "1.2.23",
+     *   {"org.apache.commons", "commons-text", null} : "1.7"
+     * }}</pre>
+     */
+    private static ProspectiveDependencies buildFromVersionMaps(
+            final LinkedHashMap<VersionlessDependency, String> compileVersionMap,
+            final LinkedHashMap<VersionlessDependency, String> runtimeVersionMap) {
+        final LinkedHashMap<VersionlessDependency, String> compileOnlyVersionMap =
+                calculateCompileOnly(compileVersionMap, runtimeVersionMap);
+        final LinkedHashMap<VersionlessDependency, String> overlappingVersionMap =
+                calculateOverlapping(compileVersionMap, runtimeVersionMap);
+        final LinkedHashMap<VersionlessDependency, String> runtimeOnlyVersionMap =
+                calculateRuntimeOnly(compileVersionMap, runtimeVersionMap);
+
+        final LinkedHashMap<VersionlessDependency, VersionScope> prospectiveDependencies = new LinkedHashMap<>();
+        for (final Map.Entry<VersionlessDependency, String> compileOnly : compileOnlyVersionMap.entrySet()) {
+            if (null != prospectiveDependencies.put(compileOnly.getKey(), VersionScope.provided(compileOnly.getValue()))) {
+                throw new GradleException("A tuple of [" + compileOnly.getKey().toString() + "] is duplicated unexpectedly.");
+            }
+        }
+        for (final Map.Entry<VersionlessDependency, String> overlapping : overlappingVersionMap.entrySet()) {
+            if (null != prospectiveDependencies.put(overlapping.getKey(), VersionScope.compile(overlapping.getValue()))) {
+                throw new GradleException("A tuple of [" + overlapping.getKey().toString() + "] is duplicated unexpectedly.");
+            }
+        }
+        for (final Map.Entry<VersionlessDependency, String> runtimeOnly : runtimeOnlyVersionMap.entrySet()) {
+            if (null != prospectiveDependencies.put(runtimeOnly.getKey(), VersionScope.runtime(runtimeOnly.getValue()))) {
+                throw new GradleException("A tuple of [" + runtimeOnly.getKey().toString() + "] is duplicated unexpectedly.");
+            }
+        }
+        return new ProspectiveDependencies(prospectiveDependencies);
+    }
+
+    @Override
+    public Iterator<ScopedDependency> iterator() {
+        return this.scopedDependencies.iterator();
+    }
+
+    @Override
+    public String toString() {
+        return this.dependencies.toString();
+    }
+
+    private static class Builder {
+        Builder() {
+            this.compileVersionMap = null;
+            this.runtimeVersionMap = null;
+            this.compileException = null;
+            this.runtimeException = null;
+        }
+
+        Builder addCompileClasspath(final Set<ResolvedArtifact> compileClasspath) {
+            if (this.compileVersionMap != null || this.compileException != null) {
+                throw new IllegalStateException(
+                        "ProspectiveDependencies.Builder.addCompileClasspath is called twice unexpectedly.");
+            }
+            try {
+                this.compileVersionMap = buildVersionMapFromResolvedArtifacts(compileClasspath);
+            } catch (final UnexpectedDependencyException ex) {
+                this.compileException = ex;
+            }
+            return this;
+        }
+
+        Builder addRuntimeClasspath(final Set<ResolvedArtifact> runtimeClasspath) {
+            if (this.runtimeVersionMap != null || this.runtimeException != null) {
+                throw new IllegalStateException(
+                        "ProspectiveDependencies.Builder.addRuntimeClasspath is called twice unexpectedly.");
+            }
+            try {
+                this.runtimeVersionMap = buildVersionMapFromResolvedArtifacts(runtimeClasspath);
+            } catch (final UnexpectedDependencyException ex) {
+                this.runtimeException = ex;
+            }
+            return this;
+        }
+
+        ProspectiveDependencies build() throws GradleException {
+            if (this.compileException != null || this.runtimeException != null) {
+                throw new GradleException();  // TODO:
+            }
+            if (this.compileVersionMap == null || this.runtimeVersionMap == null) {
+                throw new NullPointerException(
+                        "ProspectiveDependencies is built without compileClasspath or runtimeClasspath unexpectedly.");
+            }
+            return ProspectiveDependencies.buildFromVersionMaps(this.compileVersionMap, this.runtimeVersionMap);
+        }
+
+        private LinkedHashMap<VersionlessDependency, String> compileVersionMap;
+        private LinkedHashMap<VersionlessDependency, String> runtimeVersionMap;
+
+        private UnexpectedDependencyException compileException;
+        private UnexpectedDependencyException runtimeException;
+    }
+
+    private static class UnexpectedDependencyException extends Exception {
+        UnexpectedDependencyException(
+                final LinkedHashSet<VersionlessDependency> duplicates,
+                final ArrayList<LibraryBinaryIdentifier> libs,
+                final ArrayList<ComponentIdentifier> others) {
+            super(buildMessage(duplicates, libs, others));
+            this.duplicates = duplicates;
+            this.libs = libs;
+            this.others = others;
+        }
+
+        private static String buildMessage(
+                final LinkedHashSet<VersionlessDependency> duplicates,
+                final ArrayList<LibraryBinaryIdentifier> libs,
+                final ArrayList<ComponentIdentifier> others) {
+            final StringBuilder exceptionMessage = new StringBuilder();
+
+            if (!duplicates.isEmpty()) {
+                exceptionMessage.append("Dependency duplicates are found: ");
+                exceptionMessage.append(
+                        duplicates.stream().map(VersionlessDependency::toString).collect(Collectors.joining(", ", "[", "]")));
+            }
+
+            if (!libs.isEmpty()) {
+                if (exceptionMessage.length() > 0) {
+                    exceptionMessage.append(" ");
+                }
+                exceptionMessage.append("Native library binary dependencies are not supported: ");
+                exceptionMessage.append(
+                        libs.stream().map(LibraryBinaryIdentifier::getDisplayName).collect(Collectors.joining(", ", "[", "]")));
+            }
+
+            if (!others.isEmpty()) {
+                if (exceptionMessage.length() > 0) {
+                    exceptionMessage.append(" ");
+                }
+                exceptionMessage.append("Unknown type of artifacts: ");
+                exceptionMessage.append(
+                        others.stream().map(ComponentIdentifier::getDisplayName).collect(Collectors.joining(", ", "[", "]")));
+            }
+
+            return exceptionMessage.toString();
+        }
+
+        private final LinkedHashSet<VersionlessDependency> duplicates;
+        private final ArrayList<LibraryBinaryIdentifier> libs;
+        private final ArrayList<ComponentIdentifier> others;
+    }
+
+    private static LinkedHashMap<VersionlessDependency, String> buildVersionMapFromResolvedArtifacts(
+            final Set<ResolvedArtifact> artifacts)
+            throws UnexpectedDependencyException {
+        final LinkedHashMap<VersionlessDependency, String> versionMap = new LinkedHashMap<>();
+
+        final LinkedHashSet<VersionlessDependency> duplicates = new LinkedHashSet<>();
+        final ArrayList<LibraryBinaryIdentifier> libs = new ArrayList<>();
+        final ArrayList<ComponentIdentifier> others = new ArrayList<>();
+
+        for (final ResolvedArtifact artifact : artifacts) {
+            final ComponentIdentifier componentIdentifier = artifact.getId().getComponentIdentifier();
+
+            if (componentIdentifier instanceof ProjectComponentIdentifier) {
+                // @@@@
+            } else if (componentIdentifier instanceof ModuleComponentIdentifier) {
+                final ModuleComponentIdentifier moduleIdentifier = (ModuleComponentIdentifier) componentIdentifier;
+                final VersionlessDependency module = VersionlessDependency.fromModule(moduleIdentifier, artifact);
+                if (versionMap.containsKey(module)) {
+                    duplicates.add(module);
+                } else {
+                    versionMap.put(module, moduleIdentifier.getVersion());
+                }
+            } else if (componentIdentifier instanceof LibraryBinaryIdentifier) {
+                libs.add((LibraryBinaryIdentifier) componentIdentifier);
+            } else {
+                others.add(componentIdentifier);
+            }
+        }
+
+        if ((!duplicates.isEmpty()) || (!libs.isEmpty()) || (!others.isEmpty())) {
+            throw new UnexpectedDependencyException(duplicates, libs, others);
+        }
+
+        return versionMap;
+    }
+
+    private static final class VersionScope {
+        private VersionScope(final String version, final MavenScope scope) {
+            this.version = version;
+            this.scope = scope;
+        }
+
+        static VersionScope compile(final String version) {
+            return new VersionScope(version, MavenScope.COMPILE);
+        }
+
+        static VersionScope runtime(final String version) {
+            return new VersionScope(version, MavenScope.RUNTIME);
+        }
+
+        static VersionScope provided(final String version) {
+            return new VersionScope(version, MavenScope.PROVIDED);
+        }
+
+        String getVersion() {
+            return this.version;
+        }
+
+        MavenScope getScope() {
+            return this.scope;
+        }
+
+        @Override
+        public String toString() {
+            return this.version + "@" + this.scope.toString();
+        }
+
+        private final String version;
+        private final MavenScope scope;
+    }
+
+    private static LinkedHashMap<VersionlessDependency, String> calculateCompileOnly(
+            final Map<VersionlessDependency, String> compileVersionMap,
+            final Map<VersionlessDependency, String> runtimeVersionMap) {
+        final LinkedHashMap<VersionlessDependency, String> compileOnlyMap = new LinkedHashMap<>(compileVersionMap);
+        compileOnlyMap.keySet().removeAll(runtimeVersionMap.keySet());
+        return compileOnlyMap;
+    }
+
+    private static LinkedHashMap<VersionlessDependency, String> calculateRuntimeOnly(
+            final Map<VersionlessDependency, String> compileVersionMap,
+            final Map<VersionlessDependency, String> runtimeVersionMap) {
+        final LinkedHashMap<VersionlessDependency, String> runtimeOnlyMap = new LinkedHashMap<>(runtimeVersionMap);
+        runtimeOnlyMap.keySet().removeAll(compileVersionMap.keySet());
+        return runtimeOnlyMap;
+    }
+
+    private static LinkedHashMap<VersionlessDependency, String> calculateOverlapping(
+            final Map<VersionlessDependency, String> compileVersionMap,
+            final Map<VersionlessDependency, String> runtimeVersionMap) {
+        final LinkedHashMap<VersionlessDependency, String> overlappingMap = new LinkedHashMap<>(compileVersionMap);
+        // TODO: Check duplication with version mismatch.
+        overlappingMap.keySet().retainAll(runtimeVersionMap.keySet());
+        return overlappingMap;
+    }
+
+    private Map<VersionlessDependency, String> extract(final MavenScope scope) {
+        final LinkedHashMap<VersionlessDependency, String> extracted = new LinkedHashMap<>();
+        for (final Map.Entry<VersionlessDependency, VersionScope> dependency : this.dependencies.entrySet()) {
+            if (scope == dependency.getValue().getScope()) {
+                extracted.put(dependency.getKey(), dependency.getValue().getVersion());
+            }
+        }
+        return Collections.unmodifiableMap(extracted);
+    }
+
+    String toStringForLogging() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("\n");
+        for (final Map.Entry<VersionlessDependency, VersionScope> dependency : this.dependencies.entrySet()) {
+            builder.append("    => ");
+            builder.append(dependency.getKey().toString(
+                    dependency.getValue().getVersion(),
+                    dependency.getValue().getScope()));
+            builder.append("\n");
+        }
+        builder.append("");
+        return builder.toString();
+
+    }
+
+    // The primary data of dependencies.
+    private final Map<VersionlessDependency, VersionScope> dependencies;
+
+    // A cached representation of dependencies.
+    private final List<ScopedDependency> scopedDependencies;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/ScopedDependency.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/ScopedDependency.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import java.util.Objects;
+
+final class ScopedDependency {
+    private ScopedDependency(
+            final VersionlessDependency versionless,
+            final String version,
+            final MavenScope scope) {
+        this.versionless = versionless;
+        this.version = version;
+        this.scope = scope;
+    }
+
+    static ScopedDependency of(
+            final VersionlessDependency versionless,
+            final String version,
+            final MavenScope scope) {
+        return new ScopedDependency(versionless, version, scope);
+    }
+
+    VersionlessDependency getVersionlessDependency() {
+        return this.versionless;
+    }
+
+    String getVersion() {
+        return this.version;
+    }
+
+    MavenScope getScope() {
+        return this.scope;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.versionless, this.version, this.scope);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (this == otherObject) {
+            return true;
+        }
+        if (!(otherObject instanceof ScopedDependency)) {
+            return false;
+        }
+        final ScopedDependency other = (ScopedDependency) otherObject;
+        return Objects.equals(this.versionless, other.versionless)
+                && Objects.equals(this.version, other.version)
+                && Objects.equals(this.scope, other.scope);
+    }
+
+    @Override
+    public String toString() {
+        return this.versionless.toString(this.version, this.scope);
+    }
+
+    private final VersionlessDependency versionless;
+    private final String version;
+    private final MavenScope scope;
+}

--- a/src/main/java/org/embulk/gradle/embulk_plugins/VersionlessDependency.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/VersionlessDependency.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import groovy.util.Node;
+import java.util.Objects;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+
+final class VersionlessDependency {
+    private VersionlessDependency(
+            final String group,
+            final String artifactName,
+            final String classifier) {
+        final StringBuilder builder = new StringBuilder();
+
+        if (group == null) {
+            this.group = "";
+        } else {
+            this.group = group;
+            builder.append(group);
+        }
+
+        builder.append(":");
+
+        if (artifactName == null) {
+            throw new NullPointerException("artifactName must not be null.");
+        }
+        this.artifactName = artifactName;
+        builder.append(artifactName);
+
+        if (classifier == null) {
+            this.classifier = null;
+        } else {
+            this.classifier = classifier;
+            builder.append(":");
+            builder.append(classifier);
+        }
+
+        this.stringified = builder.toString();
+    }
+
+    static VersionlessDependency of(
+            final String group,
+            final String artifactName,
+            final String classifier) {
+        return new VersionlessDependency(group, artifactName, classifier);
+    }
+
+    static VersionlessDependency fromModule(final ModuleComponentIdentifier identifier, final ResolvedArtifact artifact) {
+        return new VersionlessDependency(identifier.getGroup(), identifier.getModule(), artifact.getClassifier());
+    }
+
+    String getGroup() {
+        return this.group;
+    }
+
+    String getArtifactName() {
+        return this.artifactName;
+    }
+
+    String getClassifier() {
+        return this.classifier;
+    }
+
+    Node toNode() {
+        final Node node = new Node(null, "dependency");
+        node.appendNode("groupId", this.group);
+        node.appendNode("artifactId", this.artifactName);
+        if (this.classifier != null) {
+            node.appendNode("classifier", this.classifier);
+        }
+        return node;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.group, this.artifactName, this.classifier);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (this == otherObject) {
+            return true;
+        }
+        if (!(otherObject instanceof VersionlessDependency)) {
+            return false;
+        }
+        final VersionlessDependency other = (VersionlessDependency) otherObject;
+        return Objects.equals(this.group, other.group)
+                && Objects.equals(this.artifactName, other.artifactName)
+                && Objects.equals(this.classifier, other.classifier);
+    }
+
+    @Override
+    public String toString() {
+        return this.stringified;
+    }
+
+    public String toString(final String version, final MavenScope scope) {
+        final StringBuilder builder = new StringBuilder();
+        if (this.group != null) {
+            builder.append(this.group);
+        }
+        builder.append(":");
+        builder.append(this.artifactName);
+        builder.append(":");
+        builder.append(version);
+        if (this.classifier != null) {
+            builder.append(":");
+            builder.append(this.classifier);
+        }
+        builder.append("@");
+        builder.append(scope.toString());
+        return builder.toString();
+    }
+
+    private final String group;
+    private final String artifactName;
+    private final String classifier;
+
+    private final String stringified;
+}

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestSimple.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestSimple.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.gradle.embulk_plugins;
+
+import static org.embulk.gradle.embulk_plugins.Util.prepareProjectDir;
+import static org.embulk.gradle.embulk_plugins.Util.runGradle;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests a simple case in the Embulk plugins Gradle plugin.
+ *
+ * <p>This test is tentatively disabled on Windows. {@code GradleRunner} may keep some related files open.
+ * It prevents JUnit 5 from removing the temporary directory ({@code TempDir}).
+ *
+ * @see <a href="https://github.com/embulk/gradle-embulk-plugins/runs/719452273">A failed test</a>
+ */
+class TestSimple {
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void test(@TempDir Path tempDir) throws IOException {
+        final Path projectDir = prepareProjectDir(tempDir, "testSimple");
+        runGradle(projectDir, "compileJava", "generatePomFileForEmbulkPluginMavenPublication");
+
+        final Path pomPath = projectDir.resolve("build/publications/embulkPluginMaven/pom-default.xml");
+        assertTrue(Files.exists(pomPath));
+
+        System.out.println("Generated POM :");
+        System.out.println("============================================================");
+        for (final String line : Files.readAllLines(pomPath, StandardCharsets.UTF_8)) {
+            System.out.println(line);
+        }
+        System.out.println("============================================================");
+    }
+}

--- a/src/test/resources/testSimple/build.gradle
+++ b/src/test/resources/testSimple/build.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id "java"
+    id "maven"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins"
+}
+
+group = "org.embulk.input.simple"
+archivesBaseName = "${project.name}"
+version = "0.11.22"
+description = "Embulk simple input plugin"
+
+repositories {
+    mavenCentral()
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
+dependencies {
+    compileOnly "org.embulk:embulk-api:0.10.35"
+    compileOnly "org.embulk:embulk-spi:0.10.35"
+    implementation("org.apache.commons:commons-text:1.7") {
+        exclude group: "foo", module: "bar"
+        exclude group: "foo"
+        exclude module: "bar"
+    }
+    implementation("com.github.jnr:jffi:1.2.23") {
+        exclude group: "foo", module: "bar"
+        exclude group: "*", module: "*"
+    }
+    implementation "com.github.jnr:jffi:1.2.23:native"
+}
+
+embulkPlugin {
+    mainClass = "org.embulk.input.simple.SimpleInputPlugin"
+    category = "input"
+    type = "simple"
+    directPomManipulation = true
+}
+
+publishing {
+    publications {
+        embulkPluginMaven(MavenPublication) {
+            description = "simple and stupid"
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url = "${project.buildDir}/mavenPublishLocal"
+        }
+    }
+}

--- a/src/test/resources/testSimple/settings.gradle
+++ b/src/test/resources/testSimple/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "embulk-input-simple"


### PR DESCRIPTION
# Background

A Maven-based Embulk plugin has needed to have `pom.xml` including all dependencies as the direct first-level dependencies without any transitive dependency.

This is an important restriction to keep dependencies consistent between plugin development and Embulk's runtime. Indeed, Embulk's `PluginClassLoader` is implemented for Maven-based plugins to load only the direct first-level dependencies without any transitive dependency.)

This Gradle plugin has exploited Gradle's own dependency resolution mechanism to generate such a tweaked `pom.xml` with flattening all transitive dependencies.

# Problem

But, it was just a hack. It turned out that `pom.xml` generated in that way was not perfect. #86 is a good example.

It is not a problem for the Embulk core to load a Maven-based Embulk plugin with such `pom.xml`. But, it is a problem when installing a Maven-based Embulk plugin, in some cases such as #86.

# Solution

After some investigation in Gradle, we concluded that going with exploiting Gradle's own dependency resolution is no way. Instead of that, we decided just to follow Gradle's default `compileClasspath` and `runtimeClasspath`, and to manipulate `pom.xml` generated by Gradle directly.

The old way :

1. Create another "Configuration" of Gradle: `embulkPluginRuntime`
2. Tweak `embulkPluginRuntime` to have dependencies flattened from `runtime`
3. Build everything (jar, gem, and `pom.xml`) straightforward, but based on `embulkPluginRuntime`

The new way:

1. Build everything (jar, gem) based on default `compileClasspath` and `runtimeClasspath`
2. `pom.xml` is built at the same time as 1 once
3. Manipulate the generated `pom.xml` at the last minute with Gradle's `pom.withXml` mechanism

# Side effect

As a side effect, this will support Gradle's newer dependency declaration with `implementation`, instead of older `compile`. `compile` has been marked as deprecated, and Gradle 7.0 has removed `compile`.

https://tomgregory.com/gradle-implementation-vs-compile-dependencies/

It was the reason why we had to stay with Gradle 6 for Embulk plugins. This change will unblock us to use Gradle 7.

# Migration

This new mechanism is enabled in v0.4.5 by the `directPomManipulation = true` option.

The old mechanism will be removed, and the new mechanism will be used by default from v0.5.0.

# Example

The GitHub Actions result would be a good example to understand what it does.

https://github.com/embulk/gradle-embulk-plugins/runs/6806502738?check_suite_focus=true
```
    compileClasspath:
        => org.embulk:embulk-spi:0.10.35
        => org.embulk:embulk-api:0.10.35
        => org.apache.commons:commons-text:1.7
        => com.github.jnr:jffi:1.2.23
        => com.github.jnr:jffi:native:1.2.23
        => org.msgpack:msgpack-core:0.8.11
        => org.slf4j:slf4j-api:1.7.30
        => org.apache.commons:commons-lang3:3.9

    runtimeClasspath:
        => org.apache.commons:commons-text:1.7
        => com.github.jnr:jffi:1.2.23
        => com.github.jnr:jffi:native:1.2.23
        => org.apache.commons:commons-lang3:3.9

    <dependencies> in pom.xml before manipulation:
        => org.apache.commons:commons-text:1.7@RUNTIME
        => com.github.jnr:jffi:1.2.23@RUNTIME
        => com.github.jnr:jffi:1.2.23:native@RUNTIME

    <dependencies> should be as follows, from compileClasspath and runtimeClasspath:
        => org.embulk:embulk-spi:0.10.35@PROVIDED
        => org.embulk:embulk-api:0.10.35@PROVIDED
        => org.msgpack:msgpack-core:0.8.11@PROVIDED
        => org.slf4j:slf4j-api:1.7.30@PROVIDED
        => org.apache.commons:commons-text:1.7@COMPILE
        => com.github.jnr:jffi:1.2.23@COMPILE
        => com.github.jnr:jffi:1.2.23:native@COMPILE
        => org.apache.commons:commons-lang3:3.9@COMPILE

    <dependencies> is going to be updated:
        => [INSERT] org.embulk:embulk-spi:0.10.35@PROVIDED
        => [INSERT] org.embulk:embulk-api:0.10.35@PROVIDED
        => [INSERT] org.msgpack:msgpack-core:0.8.11@PROVIDED
        => [INSERT] org.slf4j:slf4j-api:1.7.30@PROVIDED
        => [MODIFY] org.apache.commons:commons-text:1.7@COMPILE
          => Update <scope>: runtime => compile
          => Remove <exclusion><groupId>foo</groupId><artifactId>bar</artifactId></exclusion>
          => Remove <exclusion><groupId>foo</groupId><artifactId>*</artifactId></exclusion>
          => Remove <exclusion><groupId>*</groupId><artifactId>bar</artifactId></exclusion>
          => Add <exclusion><groupId>*</groupId></exclusion>
        => [MODIFY] com.github.jnr:jffi:1.2.23@COMPILE
          => Update <scope>: runtime => compile
          => Remove <exclusion><groupId>foo</groupId><artifactId>bar</artifactId></exclusion>
        => [MODIFY] com.github.jnr:jffi:1.2.23:native@COMPILE
          => Update <scope>: runtime => compile
          => Add <exclusions><exclusion><groupId>*</groupId></exclusion></exclusions>
        => [APPEND] org.apache.commons:commons-lang3:3.9@COMPILE

    <dependencies> in pom.xml after manipulation:
        => org.embulk:embulk-spi:0.10.35@PROVIDED
        => org.embulk:embulk-api:0.10.35@PROVIDED
        => org.msgpack:msgpack-core:0.8.11@PROVIDED
        => org.slf4j:slf4j-api:1.7.30@PROVIDED
        => org.apache.commons:commons-text:1.7@COMPILE
        => com.github.jnr:jffi:1.2.23@COMPILE
        => com.github.jnr:jffi:1.2.23:native@COMPILE
        => org.apache.commons:commons-lang3:3.9@COMPILE

...

    ============================================================
    Generated POM :
    ============================================================
    <?xml version="1.0" encoding="UTF-8"?>
    <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0[ http://maven.apache.org/xsd/maven-4.0.0.xs](http://maven.apache.org/xsd/maven-4.0.0.xsd)d" xmlns:xsi=["http://www.w3.org/2001/XMLSchema-instanc](http://www.w3.org/2001/XMLSchema-instance)e">
      <modelVersion>4.0.0</modelVersion>
      <groupId>org.embulk.input.simple</groupId>
      <artifactId>embulk-input-simple</artifactId>
      <version>0.11.22</version>
      <dependencies>
        <dependency>
          <groupId>org.embulk</groupId>
          <artifactId>embulk-spi</artifactId>
          <version>0.10.35</version>
          <scope>provided</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>org.embulk</groupId>
          <artifactId>embulk-api</artifactId>
          <version>0.10.35</version>
          <scope>provided</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>org.msgpack</groupId>
          <artifactId>msgpack-core</artifactId>
          <version>0.8.11</version>
          <scope>provided</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
          <version>1.7.30</version>
          <scope>provided</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-text</artifactId>
          <version>1.7</version>
          <scope>compile</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>com.github.jnr</groupId>
          <artifactId>jffi</artifactId>
          <version>1.2.23</version>
          <scope>compile</scope>
          <exclusions>
            <exclusion>
              <artifactId>*</artifactId>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>com.github.jnr</groupId>
          <artifactId>jffi</artifactId>
          <version>1.2.23</version>
          <classifier>native</classifier>
          <scope>compile</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
          <version>3.9</version>
          <scope>compile</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
      </dependencies>
    </project>
    ============================================================
```
