### PR TITLE
Re-support subproject dependencies

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -185,6 +185,8 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                         }
                     }
 
+                    xml.gleanRemainingDependencies();
+
                     xml.toCommit("<dependencies> in pom.xml after manipulation:");
                 }
             });

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
@@ -36,8 +36,9 @@ import java.nio.file.attribute.BasicFileAttributes;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -54,7 +55,7 @@ import org.xml.sax.SAXException;
  */
 class TestSubprojects {
     @Test
-    @Disabled
+    @DisabledOnOs(OS.WINDOWS)
     public void test(@TempDir Path tempDir) throws IOException {
         final Path projectDir = prepareProjectDir(tempDir, "testSubprojects");
         final Path subpluginDir = projectDir.resolve("embulk-input-subprojects_subplugin");

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
@@ -16,8 +16,10 @@
 
 package org.embulk.gradle.embulk_plugins;
 
+import static org.embulk.gradle.embulk_plugins.Util.assertExcludeAll;
 import static org.embulk.gradle.embulk_plugins.Util.assertFileDoesContain;
 import static org.embulk.gradle.embulk_plugins.Util.assertFileDoesNotContain;
+import static org.embulk.gradle.embulk_plugins.Util.assertNoElement;
 import static org.embulk.gradle.embulk_plugins.Util.assertSingleTextContentByTagName;
 import static org.embulk.gradle.embulk_plugins.Util.getSingleElementByTagName;
 import static org.embulk.gradle.embulk_plugins.Util.prepareProjectDir;
@@ -135,34 +137,67 @@ class TestSubprojects {
 
         final Element dependenciesRoot = getSingleElementByTagName(projectRoot, "dependencies");
         final NodeList dependenciesRootEach = dependenciesRoot.getElementsByTagName("dependency");
-        assertEquals(4, dependenciesRootEach.getLength());
+        assertEquals(7, dependenciesRootEach.getLength());
 
+        // "org.embulk:embulk-spi:0.10.35" => originally in build.gradle as "compileOnly".
         final Element dependencyRoot0 = (Element) dependenciesRootEach.item(0);
-        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencyRoot0, "groupId");
-        assertSingleTextContentByTagName("sublib", dependencyRoot0, "artifactId");
-        assertSingleTextContentByTagName("0.6.14", dependencyRoot0, "version");
-        assertSingleTextContentByTagName("compile", dependencyRoot0, "scope");
+        assertSingleTextContentByTagName("org.embulk", dependencyRoot0, "groupId");
+        assertSingleTextContentByTagName("embulk-spi", dependencyRoot0, "artifactId");
+        assertSingleTextContentByTagName("0.10.35", dependencyRoot0, "version");
+        assertNoElement(dependencyRoot0, "classifier");
+        assertSingleTextContentByTagName("provided", dependencyRoot0, "scope");
+        assertExcludeAll(dependencyRoot0);
 
+        // "org.embulk:embulk-api:0.10.35" => originally in build.gradle as "compileOnly".
         final Element dependencyRoot1 = (Element) dependenciesRootEach.item(1);
-        assertSingleTextContentByTagName("commons-io", dependencyRoot1, "groupId");
-        assertSingleTextContentByTagName("commons-io", dependencyRoot1, "artifactId");
-        assertSingleTextContentByTagName("2.6", dependencyRoot1, "version");
-        assertSingleTextContentByTagName("compile", dependencyRoot1, "scope");
+        assertSingleTextContentByTagName("org.embulk", dependencyRoot1, "groupId");
+        assertSingleTextContentByTagName("embulk-api", dependencyRoot1, "artifactId");
+        assertSingleTextContentByTagName("0.10.35", dependencyRoot1, "version");
+        assertNoElement(dependencyRoot1, "classifier");
+        assertSingleTextContentByTagName("provided", dependencyRoot1, "scope");
+        assertExcludeAll(dependencyRoot1);
 
-        // It is almost the same as dependencyRoot0. The only difference is "scope". It does not cause an immediate problem.
-        // It looks like a problem of Gradle's POM generation with project reference (`compile project(":subproject")`).
-        // TODO: Investigate the reason deep inside Gradle, and fix it.
+        // "org.msgpack:msgpac-core:0.8.11" => added by the Gradle plugin as "provided".
         final Element dependencyRoot2 = (Element) dependenciesRootEach.item(2);
-        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencyRoot2, "groupId");
-        assertSingleTextContentByTagName("sublib", dependencyRoot2, "artifactId");
-        assertSingleTextContentByTagName("0.6.14", dependencyRoot2, "version");
-        assertSingleTextContentByTagName("runtime", dependencyRoot2, "scope");
+        assertSingleTextContentByTagName("org.msgpack", dependencyRoot2, "groupId");
+        assertSingleTextContentByTagName("msgpack-core", dependencyRoot2, "artifactId");
+        assertSingleTextContentByTagName("0.8.11", dependencyRoot2, "version");
+        assertNoElement(dependencyRoot2, "classifier");
+        assertSingleTextContentByTagName("provided", dependencyRoot2, "scope");
+        assertExcludeAll(dependencyRoot2);
 
+        // "org.slf4j:slf4j-api:1.7.30" => added by the Gradle plugin as "provided".
         final Element dependencyRoot3 = (Element) dependenciesRootEach.item(3);
-        assertSingleTextContentByTagName("commons-lang", dependencyRoot3, "groupId");
-        assertSingleTextContentByTagName("commons-lang", dependencyRoot3, "artifactId");
-        assertSingleTextContentByTagName("2.6", dependencyRoot3, "version");
-        assertSingleTextContentByTagName("runtime", dependencyRoot3, "scope");
+        assertSingleTextContentByTagName("org.slf4j", dependencyRoot3, "groupId");
+        assertSingleTextContentByTagName("slf4j-api", dependencyRoot3, "artifactId");
+        assertSingleTextContentByTagName("1.7.30", dependencyRoot3, "version");
+        assertNoElement(dependencyRoot3, "classifier");
+        assertSingleTextContentByTagName("provided", dependencyRoot3, "scope");
+        assertExcludeAll(dependencyRoot3);
+
+        final Element dependencyRoot4 = (Element) dependenciesRootEach.item(4);
+        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencyRoot4, "groupId");
+        assertSingleTextContentByTagName("sublib", dependencyRoot4, "artifactId");
+        assertSingleTextContentByTagName("0.6.14", dependencyRoot4, "version");
+        assertNoElement(dependencyRoot4, "classifier");
+        assertSingleTextContentByTagName("compile", dependencyRoot4, "scope");
+        assertExcludeAll(dependencyRoot4);
+
+        final Element dependencyRoot5 = (Element) dependenciesRootEach.item(5);
+        assertSingleTextContentByTagName("commons-io", dependencyRoot5, "groupId");
+        assertSingleTextContentByTagName("commons-io", dependencyRoot5, "artifactId");
+        assertSingleTextContentByTagName("2.6", dependencyRoot5, "version");
+        assertNoElement(dependencyRoot5, "classifier");
+        assertSingleTextContentByTagName("compile", dependencyRoot5, "scope");
+        assertExcludeAll(dependencyRoot5);
+
+        final Element dependencyRoot6 = (Element) dependenciesRootEach.item(6);
+        assertSingleTextContentByTagName("commons-lang", dependencyRoot6, "groupId");
+        assertSingleTextContentByTagName("commons-lang", dependencyRoot6, "artifactId");
+        assertSingleTextContentByTagName("2.6", dependencyRoot6, "version");
+        assertNoElement(dependencyRoot6, "classifier");
+        assertSingleTextContentByTagName("compile", dependencyRoot6, "scope");
+        assertExcludeAll(dependencyRoot6);
 
         final Path subVersionDir = projectDir.resolve("build/mavenLocalSubprojects/org/embulk/input/test_subprojects/embulk-input-subprojects_subplugin/0.6.14");
         final Path subJarPath = subVersionDir.resolve("embulk-input-subprojects_subplugin-0.6.14.jar");
@@ -215,33 +250,66 @@ class TestSubprojects {
 
         final Element dependenciesSub = getSingleElementByTagName(project, "dependencies");
         final NodeList dependenciesSubEach = dependenciesSub.getElementsByTagName("dependency");
-        assertEquals(4, dependenciesSubEach.getLength());
+        assertEquals(7, dependenciesSubEach.getLength());
 
+        // "org.embulk:embulk-spi:0.10.35" => originally in build.gradle as "compileOnly".
         final Element dependencySub0 = (Element) dependenciesSubEach.item(0);
-        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencySub0, "groupId");
-        assertSingleTextContentByTagName("sublib", dependencySub0, "artifactId");
-        assertSingleTextContentByTagName("0.6.14", dependencySub0, "version");
-        assertSingleTextContentByTagName("compile", dependencySub0, "scope");
+        assertSingleTextContentByTagName("org.embulk", dependencySub0, "groupId");
+        assertSingleTextContentByTagName("embulk-spi", dependencySub0, "artifactId");
+        assertSingleTextContentByTagName("0.10.35", dependencySub0, "version");
+        assertNoElement(dependencySub0, "classifier");
+        assertSingleTextContentByTagName("provided", dependencySub0, "scope");
+        assertExcludeAll(dependencySub0);
 
+        // "org.embulk:embulk-api:0.10.35" => originally in build.gradle as "compileOnly".
         final Element dependencySub1 = (Element) dependenciesSubEach.item(1);
-        assertSingleTextContentByTagName("org.apache.commons", dependencySub1, "groupId");
-        assertSingleTextContentByTagName("commons-math3", dependencySub1, "artifactId");
-        assertSingleTextContentByTagName("3.6.1", dependencySub1, "version");
-        assertSingleTextContentByTagName("compile", dependencySub1, "scope");
+        assertSingleTextContentByTagName("org.embulk", dependencySub1, "groupId");
+        assertSingleTextContentByTagName("embulk-api", dependencySub1, "artifactId");
+        assertSingleTextContentByTagName("0.10.35", dependencySub1, "version");
+        assertNoElement(dependencySub1, "classifier");
+        assertSingleTextContentByTagName("provided", dependencySub1, "scope");
+        assertExcludeAll(dependencySub1);
 
-        // It is almost the same as dependencySub0. The only difference is "scope". It does not cause an immediate problem.
-        // It looks like a problem of Gradle's POM generation with project reference (`compile project(":subproject")`).
-        // TODO: Investigate the reason deep inside Gradle, and fix it.
+        // "org.msgpack:msgpac-core:0.8.11" => added by the Gradle plugin as "provided".
         final Element dependencySub2 = (Element) dependenciesSubEach.item(2);
-        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencySub2, "groupId");
-        assertSingleTextContentByTagName("sublib", dependencySub2, "artifactId");
-        assertSingleTextContentByTagName("0.6.14", dependencySub2, "version");
-        assertSingleTextContentByTagName("runtime", dependencySub2, "scope");
+        assertSingleTextContentByTagName("org.msgpack", dependencySub2, "groupId");
+        assertSingleTextContentByTagName("msgpack-core", dependencySub2, "artifactId");
+        assertSingleTextContentByTagName("0.8.11", dependencySub2, "version");
+        assertNoElement(dependencySub2, "classifier");
+        assertSingleTextContentByTagName("provided", dependencySub2, "scope");
+        assertExcludeAll(dependencySub2);
 
+        // "org.slf4j:slf4j-api:1.7.30" => added by the Gradle plugin as "provided".
         final Element dependencySub3 = (Element) dependenciesSubEach.item(3);
-        assertSingleTextContentByTagName("commons-lang", dependencySub3, "groupId");
-        assertSingleTextContentByTagName("commons-lang", dependencySub3, "artifactId");
-        assertSingleTextContentByTagName("2.6", dependencySub3, "version");
-        assertSingleTextContentByTagName("runtime", dependencySub3, "scope");
+        assertSingleTextContentByTagName("org.slf4j", dependencySub3, "groupId");
+        assertSingleTextContentByTagName("slf4j-api", dependencySub3, "artifactId");
+        assertSingleTextContentByTagName("1.7.30", dependencySub3, "version");
+        assertNoElement(dependencySub3, "classifier");
+        assertSingleTextContentByTagName("provided", dependencySub3, "scope");
+        assertExcludeAll(dependencySub3);
+
+        final Element dependencySub4 = (Element) dependenciesSubEach.item(4);
+        assertSingleTextContentByTagName("org.embulk.input.test_subprojects", dependencySub4, "groupId");
+        assertSingleTextContentByTagName("sublib", dependencySub4, "artifactId");
+        assertSingleTextContentByTagName("0.6.14", dependencySub4, "version");
+        assertNoElement(dependencySub4, "classifier");
+        assertSingleTextContentByTagName("compile", dependencySub4, "scope");
+        assertExcludeAll(dependencySub4);
+
+        final Element dependencySub5 = (Element) dependenciesSubEach.item(5);
+        assertSingleTextContentByTagName("org.apache.commons", dependencySub5, "groupId");
+        assertSingleTextContentByTagName("commons-math3", dependencySub5, "artifactId");
+        assertSingleTextContentByTagName("3.6.1", dependencySub5, "version");
+        assertNoElement(dependencySub5, "classifier");
+        assertSingleTextContentByTagName("compile", dependencySub5, "scope");
+        assertExcludeAll(dependencySub5);
+
+        final Element dependencySub6 = (Element) dependenciesSubEach.item(6);
+        assertSingleTextContentByTagName("commons-lang", dependencySub6, "groupId");
+        assertSingleTextContentByTagName("commons-lang", dependencySub6, "artifactId");
+        assertSingleTextContentByTagName("2.6", dependencySub6, "version");
+        assertNoElement(dependencySub6, "classifier");
+        assertSingleTextContentByTagName("compile", dependencySub6, "scope");
+        assertExcludeAll(dependencySub6);
     }
 }

--- a/src/test/resources/testSubprojects/build.gradle
+++ b/src/test/resources/testSubprojects/build.gradle
@@ -26,7 +26,8 @@ allprojects {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-core:0.10.35"
+    compileOnly "org.embulk:embulk-api:0.10.35"
+    compileOnly "org.embulk:embulk-spi:0.10.35"
     compile project(":sublib")
     compile "commons-io:commons-io:2.6"
 }

--- a/src/test/resources/testSubprojects/embulk-input-subprojects_subplugin/build.gradle
+++ b/src/test/resources/testSubprojects/embulk-input-subprojects_subplugin/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-core:0.10.35"
+    compileOnly "org.embulk:embulk-api:0.10.35"
+    compileOnly "org.embulk:embulk-spi:0.10.35"
     compile project(":sublib")
     compile "org.apache.commons:commons-math3:3.6.1"
 }


### PR DESCRIPTION
In v0.5.0's direct pom.xml manipulation, we tentatively disabled the support for "subproject" dependencies.

We're making it supported again in v0.5.1.