### PR TITLE
Support manual additional dependency declarations with "optional"

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -186,6 +186,7 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
                     }
 
                     xml.gleanRemainingDependencies();
+                    xml.addDependencyDeclarations(extension.getAdditionalDependencyDeclarationsAsScopedDependency());
 
                     xml.toCommit("<dependencies> in pom.xml after manipulation:");
                 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/ScopedDependency.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/ScopedDependency.java
@@ -16,23 +16,86 @@
 
 package org.embulk.gradle.embulk_plugins;
 
+import java.util.Map;
 import java.util.Objects;
 
 final class ScopedDependency {
     private ScopedDependency(
             final VersionlessDependency versionless,
             final String version,
-            final MavenScope scope) {
+            final MavenScope scope,
+            final boolean optional) {
         this.versionless = versionless;
         this.version = version;
         this.scope = scope;
+        this.optional = optional;
     }
 
     static ScopedDependency of(
             final VersionlessDependency versionless,
             final String version,
             final MavenScope scope) {
-        return new ScopedDependency(versionless, version, scope);
+        return new ScopedDependency(versionless, version, scope, false);
+    }
+
+    /**
+     * Creates an instance of {@link ScopedDependency} from {@code Map<String, Object>} to be declared in {@code build.gradle}.
+     */
+    static ScopedDependency ofMap(final Map<String, Object> map) {
+        String groupId = null;
+        String artifactId = null;
+        String classifier = null;
+        String version = null;
+        String scope = null;
+        Boolean optional = null;  // null, true, or false
+
+        for (final Map.Entry<String, Object> entry : map.entrySet()) {
+            switch (entry.getKey()) {
+                case "groupId":
+                    if (entry.getValue() instanceof String) {
+                        groupId = (String) entry.getValue();
+                    }
+                    break;
+                case "artifactId":
+                    if (entry.getValue() instanceof String) {
+                        artifactId = (String) entry.getValue();
+                    }
+                    break;
+                case "classifier":
+                    if (entry.getValue() instanceof String) {
+                        classifier = (String) entry.getValue();
+                    }
+                    break;
+                case "version":
+                    if (entry.getValue() instanceof String) {
+                        version = (String) entry.getValue();
+                    }
+                    break;
+                case "scope":
+                    if (entry.getValue() instanceof String) {
+                        scope = (String) entry.getValue();
+                    }
+                    break;
+                case "optional":
+                    if (entry.getValue() instanceof Boolean) {
+                        optional = (Boolean) entry.getValue();
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException("\"" + entry.getKey() + "\" is not accepted as a Maven dependency.");
+            }
+        }
+
+        if (groupId == null || artifactId == null || version == null || scope == null) {
+            throw new NullPointerException(
+                    "\"groupId\", \"artifactId\", \"version\", and \"scope\" are mandatory in a Maven dependency.");
+        }
+
+        return new ScopedDependency(
+                VersionlessDependency.of(groupId, artifactId, classifier),
+                version,
+                MavenScope.of(scope),
+                optional == null ? false : (boolean) optional);
     }
 
     VersionlessDependency getVersionlessDependency() {
@@ -47,9 +110,13 @@ final class ScopedDependency {
         return this.scope;
     }
 
+    boolean isOptional() {
+        return this.optional;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(this.versionless, this.version, this.scope);
+        return Objects.hash(this.versionless, this.version, this.scope, this.optional);
     }
 
     @Override
@@ -63,7 +130,8 @@ final class ScopedDependency {
         final ScopedDependency other = (ScopedDependency) otherObject;
         return Objects.equals(this.versionless, other.versionless)
                 && Objects.equals(this.version, other.version)
-                && Objects.equals(this.scope, other.scope);
+                && Objects.equals(this.scope, other.scope)
+                && (this.optional == other.optional);
     }
 
     @Override
@@ -74,4 +142,5 @@ final class ScopedDependency {
     private final VersionlessDependency versionless;
     private final String version;
     private final MavenScope scope;
+    private final boolean optional;
 }

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestPublish.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestPublish.java
@@ -117,7 +117,7 @@ class TestPublish {
         // The behavior is not intended, not very good, but acceptable as of now.
         //
         // TODO: Upgrade the base Gradle, and test it in later Gradle.
-        assertEquals(8, dependenciesEach.getLength());
+        assertEquals(10, dependenciesEach.getLength());
 
         // "org.embulk:embulk-spi:0.10.35" => originally in build.gradle as "compileOnly".
         final Element dependency0 = (Element) dependenciesEach.item(0);
@@ -194,5 +194,25 @@ class TestPublish {
         assertNoElement(dependency7, "classifier");
         assertSingleTextContentByTagName("compile", dependency7, "scope");
         assertExcludeAll(dependency7);
+
+        // "example:dummy:10.11.12" => added in "additionalDependencyDeclarations".
+        final Element dependency8 = (Element) dependenciesEach.item(8);
+        assertSingleTextContentByTagName("example", dependency8, "groupId");
+        assertSingleTextContentByTagName("dummy", dependency8, "artifactId");
+        assertSingleTextContentByTagName("10.11.12", dependency8, "version");
+        assertNoElement(dependency8, "classifier");
+        assertSingleTextContentByTagName("compile", dependency8, "scope");
+        assertNoElement(dependency8, "optional");
+        assertExcludeAll(dependency8);
+
+        // "test:fake:3.14" (optional: true) => added in "additionalDependencyDeclarations".
+        final Element dependency9 = (Element) dependenciesEach.item(9);
+        assertSingleTextContentByTagName("test", dependency9, "groupId");
+        assertSingleTextContentByTagName("fake", dependency9, "artifactId");
+        assertSingleTextContentByTagName("3.14", dependency9, "version");
+        assertNoElement(dependency9, "classifier");
+        assertSingleTextContentByTagName("runtime", dependency9, "scope");
+        assertSingleTextContentByTagName("true", dependency9, "optional");
+        assertExcludeAll(dependency9);
     }
 }

--- a/src/test/resources/testPublish/build.gradle
+++ b/src/test/resources/testPublish/build.gradle
@@ -34,6 +34,10 @@ embulkPlugin {
     mainClass = "org.embulk.input.test1.Test1InputPlugin"
     category = "input"
     type = "test1"
+    additionalDependencyDeclarations = [
+        [ groupId: "example", artifactId: "dummy", version: "10.11.12", scope: "compile" ],
+        [ groupId: "test", artifactId: "fake", version: "3.14", scope: "runtime", optional: true ],
+    ]
 }
 
 publishing {


### PR DESCRIPTION
In v0.5.2, we support "additional dependency declarations" directly for pom.xml.

It can be used in `build.gradle` like below :
```
embulkPlugin {
    mainClass = "org.embulk.input.test1.Test1InputPlugin"
    category = "input"
    type = "test1"
    additionalDependencyDeclarations = [
        [ groupId: "example", artifactId: "dummy", version: "10.11.12", scope: "compile" ],
        [ groupId: "test", artifactId: "fake", version: "3.14", scope: "runtime", optional: true ],
    ]
}
```

If the Gradle plugin finds the `additionalDependencyDeclarations`, it forcibly adds `<dependency>` tags like below, regardless of the actual `dependencies {}` declaration in `build.gradle` :

```
...
        <dependency>
          <groupId>example</groupId>
          <artifactId>dummy</artifactId>
          <version>10.11.12</version>
          <scope>compile</scope>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
        <dependency>
          <groupId>test</groupId>
          <artifactId>fake</artifactId>
          <version>3.14</version>
          <scope>runtime</scope>
          <optional>true</optional>
          <exclusions>
            <exclusion>
              <groupId>*</groupId>
            </exclusion>
          </exclusions>
        </dependency>
...
```

It'll be used, for example, in `embulk-input/output-jdbc` and `embulk-input-ftp`.

`embulk-input/output-mysql` and `embulk-input/output-postgresql` have their "default" JDBC drivers. Those are resolved in their RubyGem forms, but not resolved in their Maven forms. For example, the MySQL JDBC driver is not included in `embulk-input-mysql`'s `pom.xml`. This would help including the JDBC driver in `pom.xml`.

https://repo1.maven.org/maven2/org/embulk/embulk-input-mysql/0.12.4/embulk-input-mysql-0.12.4.pom

Similar in `embulk-input-ftp`. `ftp4j:1.7.2` is not released in Maven Central, then `embulk-input-ftp` needed to include it in the Git repository. Ordinary OSS users are still unable to use the Maven form only with Maven Central, even if we include `ftp4j:1.7.2` in `pom.xml`. But, if they have their own local Maven repository (such as JFrog's), they can use it.

https://github.com/embulk/embulk-input-ftp/blob/v0.3.0/build.gradle#L57