### PR TITLE
Get test build files ready for Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "maven"
     id "java-gradle-plugin"
     id "checkstyle"
     id "com.gradle.plugin-publish" version "0.20.0"

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginRuntimeConfiguration.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestEmbulkPluginRuntimeConfiguration.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.gradle.util.GradleVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -45,7 +46,12 @@ class TestEmbulkPluginRuntimeConfiguration {
         final Path projectDir = prepareProjectDir(tempDir, "testEmbulkPluginRuntimeConfiguration");
 
         runGradle(projectDir, "dependencies", "--configuration", "runtimeClasspath", "--write-locks");
-        final Path lockfilePath = projectDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        final Path lockfilePath;
+        if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
+            lockfilePath = projectDir.resolve("gradle.lockfile");
+        } else {
+            lockfilePath = projectDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        }
         assertTrue(Files.exists(lockfilePath));
         assertFileDoesNotContain(lockfilePath, "javax.inject:javax.inject");
         assertFileDoesNotContain(lockfilePath, "org.apache.commons:commons-lang3");

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
@@ -38,6 +38,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.gradle.util.GradleVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -63,7 +64,12 @@ class TestSubprojects {
         final Path subpluginDir = projectDir.resolve("embulk-input-subprojects_subplugin");
 
         runGradle(projectDir, ":dependencies", "--configuration", "runtimeClasspath", "--write-locks");
-        final Path rootLockfilePath = projectDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        final Path rootLockfilePath;
+        if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
+            rootLockfilePath = projectDir.resolve("gradle.lockfile");
+        } else {
+            rootLockfilePath = projectDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        }
         for (final String line : Files.readAllLines(rootLockfilePath, StandardCharsets.UTF_8)) {
             System.out.println(line);
         }
@@ -74,7 +80,12 @@ class TestSubprojects {
         assertFileDoesNotContain(rootLockfilePath, "org.apache.commons:commons-math3:3.6.1");
 
         runGradle(projectDir, ":embulk-input-subprojects_subplugin:dependencies", "--configuration", "runtimeClasspath", "--write-locks");
-        final Path subpluginLockfilePath = subpluginDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        final Path subpluginLockfilePath;
+        if (GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0) {
+            subpluginLockfilePath = subpluginDir.resolve("gradle.lockfile");
+        } else {
+            subpluginLockfilePath = subpluginDir.resolve("gradle/dependency-locks/runtimeClasspath.lockfile");
+        }
         for (final String line : Files.readAllLines(subpluginLockfilePath, StandardCharsets.UTF_8)) {
             System.out.println(line);
         }

--- a/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
+++ b/src/test/java/org/embulk/gradle/embulk_plugins/TestSubprojects.java
@@ -180,7 +180,7 @@ class TestSubprojects {
         assertSingleTextContentByTagName("sublib", dependencyRoot4, "artifactId");
         assertSingleTextContentByTagName("0.6.14", dependencyRoot4, "version");
         assertNoElement(dependencyRoot4, "classifier");
-        assertSingleTextContentByTagName("compile", dependencyRoot4, "scope");
+        assertSingleTextContentByTagName("runtime", dependencyRoot4, "scope");
         assertExcludeAll(dependencyRoot4);
 
         final Element dependencyRoot5 = (Element) dependenciesRootEach.item(5);
@@ -196,7 +196,7 @@ class TestSubprojects {
         assertSingleTextContentByTagName("commons-lang", dependencyRoot6, "artifactId");
         assertSingleTextContentByTagName("2.6", dependencyRoot6, "version");
         assertNoElement(dependencyRoot6, "classifier");
-        assertSingleTextContentByTagName("compile", dependencyRoot6, "scope");
+        assertSingleTextContentByTagName("runtime", dependencyRoot6, "scope");
         assertExcludeAll(dependencyRoot6);
 
         final Path subVersionDir = projectDir.resolve("build/mavenLocalSubprojects/org/embulk/input/test_subprojects/embulk-input-subprojects_subplugin/0.6.14");
@@ -293,7 +293,7 @@ class TestSubprojects {
         assertSingleTextContentByTagName("sublib", dependencySub4, "artifactId");
         assertSingleTextContentByTagName("0.6.14", dependencySub4, "version");
         assertNoElement(dependencySub4, "classifier");
-        assertSingleTextContentByTagName("compile", dependencySub4, "scope");
+        assertSingleTextContentByTagName("runtime", dependencySub4, "scope");
         assertExcludeAll(dependencySub4);
 
         final Element dependencySub5 = (Element) dependenciesSubEach.item(5);
@@ -309,7 +309,7 @@ class TestSubprojects {
         assertSingleTextContentByTagName("commons-lang", dependencySub6, "artifactId");
         assertSingleTextContentByTagName("2.6", dependencySub6, "version");
         assertNoElement(dependencySub6, "classifier");
-        assertSingleTextContentByTagName("compile", dependencySub6, "scope");
+        assertSingleTextContentByTagName("runtime", dependencySub6, "scope");
         assertExcludeAll(dependencySub6);
     }
 }

--- a/src/test/resources/testEmbulkPluginRuntimeConfiguration/build.gradle
+++ b/src/test/resources/testEmbulkPluginRuntimeConfiguration/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "maven"
     id "maven-publish"
     id "org.embulk.embulk-plugins"
 }
@@ -24,14 +23,14 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     compileOnly "org.embulk:embulk-core:0.10.35"
-    compile("org.glassfish.jersey.core:jersey-client:2.25.1") {
+    implementation("org.glassfish.jersey.core:jersey-client:2.25.1") {
         exclude group: "javax.inject", module: "javax.inject"
     }
-    compile("org.apache.bval:bval-jsr303:0.5") {
+    implementation("org.apache.bval:bval-jsr303:0.5") {
         exclude group: "org.apache.commons", module: "commons-lang3"
     }
-    compile "com.github.jnr:jffi:1.2.23"
-    compile "com.github.jnr:jffi:1.2.23:native"
+    implementation "com.github.jnr:jffi:1.2.23"
+    implementation "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {

--- a/src/test/resources/testNoGenerateRubyCode/build.gradle
+++ b/src/test/resources/testNoGenerateRubyCode/build.gradle
@@ -23,9 +23,9 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     compileOnly "org.embulk:embulk-core:0.10.35"
-    compile "javax.json:javax.json-api:1.1.4"
-    compile "com.github.jnr:jffi:1.2.23"
-    compile "com.github.jnr:jffi:1.2.23:native"
+    implementation "javax.json:javax.json-api:1.1.4"
+    implementation "com.github.jnr:jffi:1.2.23"
+    implementation "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {

--- a/src/test/resources/testPublish/build.gradle
+++ b/src/test/resources/testPublish/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "maven"
     id "maven-publish"
     id "org.embulk.embulk-plugins"
 }
@@ -25,9 +24,9 @@ tasks.withType(JavaCompile) {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.35"
     compileOnly "org.embulk:embulk-spi:0.10.35"
-    compile "org.apache.commons:commons-text:1.7"
-    compile "com.github.jnr:jffi:1.2.23"
-    compile "com.github.jnr:jffi:1.2.23:native"
+    implementation "org.apache.commons:commons-text:1.7"
+    implementation "com.github.jnr:jffi:1.2.23"
+    implementation "com.github.jnr:jffi:1.2.23:native"
 }
 
 embulkPlugin {

--- a/src/test/resources/testSimple/build.gradle
+++ b/src/test/resources/testSimple/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "maven"
     id "maven-publish"
     id "org.embulk.embulk-plugins"
 }
@@ -41,7 +40,6 @@ embulkPlugin {
     mainClass = "org.embulk.input.simple.SimpleInputPlugin"
     category = "input"
     type = "simple"
-    directPomManipulation = true
 }
 
 publishing {

--- a/src/test/resources/testSubprojects/build.gradle
+++ b/src/test/resources/testSubprojects/build.gradle
@@ -28,8 +28,8 @@ allprojects {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.35"
     compileOnly "org.embulk:embulk-spi:0.10.35"
-    compile project(":sublib")
-    compile "commons-io:commons-io:2.6"
+    implementation project(":sublib")
+    implementation "commons-io:commons-io:2.6"
 }
 
 embulkPlugin {

--- a/src/test/resources/testSubprojects/embulk-input-subprojects_subplugin/build.gradle
+++ b/src/test/resources/testSubprojects/embulk-input-subprojects_subplugin/build.gradle
@@ -12,8 +12,8 @@ repositories {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.35"
     compileOnly "org.embulk:embulk-spi:0.10.35"
-    compile project(":sublib")
-    compile "org.apache.commons:commons-math3:3.6.1"
+    implementation project(":sublib")
+    implementation "org.apache.commons:commons-math3:3.6.1"
 }
 
 embulkPlugin {

--- a/src/test/resources/testSubprojects/sublib/build.gradle
+++ b/src/test/resources/testSubprojects/sublib/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-lang:commons-lang:2.6"
+    implementation "commons-lang:commons-lang:2.6"
 }
 
 publishing {


### PR DESCRIPTION
* `maven` plugin is no longer available in Gradle 7+.
* Gradle 7+'s dependency lockfile is `/gradle.lockfile`, instead of `/gradle/dependency-locks/*.lockfile`.
* `compile` is no longer available in Gradle 7+. (Use `implementation` instead.)
  * Some `pom.xml` dependencies change to `runtime` from `compile`.