### PR TITLE
Fix publishing from GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,9 @@ jobs:
     - name: Publish
       run: ./gradlew --stacktrace publishPlugins
       env:
+        GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+        GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        # "ORG_GRADLE_PROJECT_" environment variables with dots do not work indeed.
+        # https://github.com/gradle/gradle/issues/1295
         ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.GRADLE_PUBLISH_KEY }}
         ORG_GRADLE_PROJECT_gradle.publish.secret: ${{ secrets.GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
Publishing with #131 did not work: https://github.com/embulk/gradle-embulk-plugins/runs/7401822667?check_suite_focus=true

Environment variables like `ORG_GRADLE_PROJECT_gradle.publish.key` were not working. Instead, specifying `GRADLE_PUBLISH_KEY` directly as shown in the Actions log above.