### PR TITLE
Add internal annotation for the "gemPush" task

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
         - windows-latest
         gradle:
         - "6.4.1"
-        - "7.4.2"
+        - "7.5.1"
     steps:
     - name: Set Git's core.autocrlf to false for Windows before checkout
       run: git config --global core.autocrlf false

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.5.3-SNAPSHOT"
+version = "0.5.4-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
@@ -34,6 +34,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecResult;
 import org.gradle.work.ChangeType;
@@ -174,6 +175,7 @@ abstract class GemPush extends DefaultTask {
         logger.lifecycle("Executing `gem push` finished successfully.");
     }
 
+    @Internal
     public Property<String> getHost() {
         return this.host;
     }


### PR DESCRIPTION
Maybe from Gradle 7.5 (?), `gemPush` started to fail due to :

```
A problem was found with the configuration of task ':gemPush' (type 'GemPush').
  - In plugin 'org.embulk.embulk-plugins' type 'org.embulk.gradle.embulk_plugins.GemPush' property 'host' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#missing_annotation for more details about this problem.
```
