### PR TITLE
Re-enable the "mainJar" configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.5.4-SNAPSHOT"
+version = "0.5.5-SNAPSHOT"
 description = "A Gradle plugin to build and publish Embulk plugins"
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginExtension.java
@@ -39,6 +39,7 @@ import org.gradle.api.provider.Property;
  *     mainClass = "org.embulk.input.example.ExampleInputPlugin"
  *     category = "input"
  *     type = "example"
+ *     // mainJar = "shadowJar"  -- Experimental: It may not work.
  * }}</pre>
  */
 public class EmbulkPluginExtension {
@@ -123,8 +124,7 @@ public class EmbulkPluginExtension {
         }
 
         if (this.mainJar.isPresent()) {
-            throw new GradleException(
-                    "Failed to configure \"embulkPlugin\" because \"mainJar\" is no longer supported.");
+            this.project.getLogger().warn("\"mainJar\" is experimental. Note that it may not work well.");
         }
 
         if (!this.directPomManipulation.getOrElse(true)) {


### PR DESCRIPTION
It has been disabled since https://github.com/embulk/gradle-embulk-plugins/pull/118 because it looked depending on the mapToMavenScope things, but it may work indeed.

This commit re-enables it just as experimental.