### PR TITLE
Use JRuby 9.4.3.0 by default for gem and gemPush

### DIFF
--- a/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/EmbulkPluginsPlugin.java
@@ -290,6 +290,4 @@ public class EmbulkPluginsPlugin implements Plugin<Project> {
             return mavenVersion;
         }
     }
-
-    static final String DEFAULT_JRUBY = "org.jruby:jruby-complete:9.2.7.0";
 }

--- a/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/Gem.java
@@ -106,7 +106,7 @@ class Gem extends AbstractArchiveTask {
         this.generateGemspec.set(true);
 
         this.jruby = objectFactory.property(Object.class);
-        this.jruby.set(EmbulkPluginsPlugin.DEFAULT_JRUBY);
+        this.jruby.set(DEFAULT_JRUBY);
 
         this.getArchiveExtension().set("gem");
     }
@@ -489,6 +489,8 @@ class Gem extends AbstractArchiveTask {
         builder.append(pathElementStream.map(pathElement -> pathElement.toString()).collect(Collectors.joining("/")));
         return builder.toString();
     }
+
+    static final String DEFAULT_JRUBY = "org.jruby:jruby-complete:9.4.3.0";
 
     private final Property<String> embulkPluginMainClass;
     private final Property<String> embulkPluginCategory;

--- a/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
+++ b/src/main/java/org/embulk/gradle/embulk_plugins/GemPush.java
@@ -70,7 +70,7 @@ abstract class GemPush extends DefaultTask {
         this.host = objectFactory.property(String.class);
 
         this.jruby = objectFactory.property(Object.class);
-        this.jruby.set(EmbulkPluginsPlugin.DEFAULT_JRUBY);
+        this.jruby.set(Gem.DEFAULT_JRUBY);
     }
 
     @Incremental


### PR DESCRIPTION
It would not resolve #141 immediately (due to JRuby's issue), but anyway, we may want to use a newer version for `gem` and `gemPush` by default.